### PR TITLE
Move toggles to bottom

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,24 +9,6 @@
 </head>
 <body>
     <div id="app-container">
-        <header class="main-header">
-            <div class="header-buttons">
-                <button onclick="toggleDebug()" class="debug-toggle">Debug ▼</button>
-                <button onclick="toggleSubsystem('planner')" class="subsystem-toggle planner-toggle">
-                    Planner <span class="message-count planner-count">0</span> ▼
-                </button>
-                <button onclick="toggleSubsystem('coordinator')" class="subsystem-toggle coordinator-toggle">
-                    Coordinator <span class="message-count coordinator-count">0</span> ▼
-                </button>
-                <button onclick="toggleSubsystem('ego')" class="subsystem-toggle ego-toggle">
-                    Ego <span class="message-count ego-count">0</span> ▼
-                </button>
-                <button onclick="toggleSystemErrors()" class="subsystem-toggle system-error-toggle">
-                    System Errors <span class="message-count system-error-count">0</span> ▼
-                </button>
-            </div>
-        </header>
-
         <div class="main-content">
             <div id="chat-container" class="chat-panel">
                 <div id="messages"></div>
@@ -77,6 +59,23 @@
                 </div>
             </div>
         </div>
+        <header class="main-header">
+            <div class="header-buttons">
+                <button onclick="toggleDebug()" class="debug-toggle">Debug ▼</button>
+                <button onclick="toggleSubsystem('planner')" class="subsystem-toggle planner-toggle">
+                    Planner <span class="message-count planner-count">0</span> ▼
+                </button>
+                <button onclick="toggleSubsystem('coordinator')" class="subsystem-toggle coordinator-toggle">
+                    Coordinator <span class="message-count coordinator-count">0</span> ▼
+                </button>
+                <button onclick="toggleSubsystem('ego')" class="subsystem-toggle ego-toggle">
+                    Ego <span class="message-count ego-count">0</span> ▼
+                </button>
+                <button onclick="toggleSystemErrors()" class="subsystem-toggle system-error-toggle">
+                    System Errors <span class="message-count system-error-count">0</span> ▼
+                </button>
+            </div>
+        </header>
     </div>
 
     <!-- Debug Modal -->

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -21,6 +21,7 @@ header {
     padding: 10px 20px;
     text-align: right;
     background: transparent;
+    margin-top: auto;
 }
 
 .header-buttons {


### PR DESCRIPTION
## Summary
- relocate toggle buttons to the bottom of the page
- ensure the toggle bar stays at the end of the flex column

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454a62179c83289cc278ad07f2f23d