### PR TITLE
Add configurable model and STT options

### DIFF
--- a/src/core/ego/index.js
+++ b/src/core/ego/index.js
@@ -10,6 +10,7 @@ const memory = require('../memory');
 const sharedEventEmitter = require('../../utils/eventEmitter');
 const prompts = require('./prompts');
 const reflectionPrompts = require('./reflection-prompts');
+const { loadSettings } = require('../../utils/settings');
 
 /**
  * Escapes HTML special characters to prevent XSS
@@ -357,7 +358,10 @@ class Ego {
             }
 
             const openai = getOpenAIClient();
-            const response = await openai.chat(messages);
+            const settings = loadSettings();
+            const response = await openai.chat(messages, {
+                model: settings.bubbleModel || settings.llmModel
+            });
             
             // Try to parse the response as JSON with chat and canvas content
             let responseData = { 

--- a/src/core/evaluator/index.js
+++ b/src/core/evaluator/index.js
@@ -2,6 +2,7 @@ const { getOpenAIClient } = require('../../utils/openaiClient');
 const logger = require('../../utils/logger');
 const sharedEventEmitter = require('../../utils/eventEmitter');
 const prompts = require('./prompts');
+const { loadSettings } = require('../../utils/settings');
 
 /**
  * Evaluates the execution results against the original request
@@ -76,8 +77,9 @@ async function getEvaluation(prompt) {
         role: "user",
         content: prompt
     }];
+    const settings = loadSettings();
     const response = await openai.chat(messages, {
-        model: 'gpt-4.1-mini',
+        model: settings.evaluatorModel || settings.llmModel,
         response_format: prompts.EVALUATION_SCHEMA,
         temperature: 0.7,
         max_tokens: 1000

--- a/src/core/planner/index.js
+++ b/src/core/planner/index.js
@@ -5,6 +5,7 @@ const logger = require('../../utils/logger.js');
 const memory = require('../memory');
 const sharedEventEmitter = require('../../utils/eventEmitter');
 const prompts = require('./prompts');
+const { loadSettings } = require('../../utils/settings');
 
 const openai = getOpenAIClient();
 
@@ -117,7 +118,9 @@ async function planner(enrichedMessage, client = null) {
             }
         });
 
+        const settings = loadSettings();
         const planningResponse = await openai.chat(planningPrompts, {
+            model: settings.plannerModel || settings.llmModel,
             response_format: prompts.PLAN_SCHEMA,
             temperature: 0.7,
             max_tokens: 2000

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,50 @@ const logger = require("./utils/logger");
 const sharedEventEmitter = require("./utils/eventEmitter");
 const { ElevenLabsClient } = require('@elevenlabs/elevenlabs-js');
 const safeStringify = require('./utils/safeStringify');
+const { loadSettings, saveSettings } = require('./utils/settings');
 const app = express();
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 app.use(express.static("public"));
+
+// Simple settings page
+app.get('/settings', (req, res) => {
+    const settings = loadSettings();
+    const html = `<!DOCTYPE html>
+<html><head><title>Settings</title></head><body>
+<h1>App Settings</h1>
+<form method="POST" action="/settings">
+  <label>LLM Model:<input type="text" name="llmModel" value="${settings.llmModel}" placeholder="default" /></label><br/>
+  <label>Planner Model:<input type="text" name="plannerModel" value="${settings.plannerModel}" placeholder="default" /></label><br/>
+  <label>Evaluator Model:<input type="text" name="evaluatorModel" value="${settings.evaluatorModel}" placeholder="default" /></label><br/>
+  <label>Query Model:<input type="text" name="queryModel" value="${settings.queryModel}" placeholder="default" /></label><br/>
+  <label>Bubble Model:<input type="text" name="bubbleModel" value="${settings.bubbleModel}" placeholder="default" /></label><br/>
+  <label>TTS Voice ID:<input type="text" name="ttsVoiceId" value="${settings.ttsVoiceId}" /></label><br/>
+  <label>TTS Model ID:<input type="text" name="ttsModelId" value="${settings.ttsModelId}" /></label><br/>
+  <label>STT Sample Rate:<input type="number" name="sttSampleRate" value="${settings.sttSampleRate}" /></label><br/>
+  <label>STT Formatted Finals:<input type="checkbox" name="sttFormattedFinals" ${settings.sttFormattedFinals ? 'checked' : ''} /></label><br/>
+  <button type="submit">Save</button>
+</form>
+</body></html>`;
+    res.send(html);
+});
+
+app.post('/settings', (req, res) => {
+    const current = loadSettings();
+    const newSettings = {
+        llmModel: req.body.llmModel || current.llmModel,
+        plannerModel: req.body.plannerModel || current.plannerModel,
+        evaluatorModel: req.body.evaluatorModel || current.evaluatorModel,
+        queryModel: req.body.queryModel || current.queryModel,
+        bubbleModel: req.body.bubbleModel || current.bubbleModel,
+        ttsVoiceId: req.body.ttsVoiceId || current.ttsVoiceId,
+        ttsModelId: req.body.ttsModelId || current.ttsModelId,
+        sttSampleRate: parseInt(req.body.sttSampleRate, 10) || current.sttSampleRate,
+        sttFormattedFinals: req.body.sttFormattedFinals ? true : false
+    };
+    saveSettings(newSettings);
+    res.redirect('/settings');
+});
 
 // Ensure .env variables are loaded
 require('dotenv').config();
@@ -25,13 +66,23 @@ app.get('/api/assemblyai-token', (req, res) => {
   // For actual AssemblyAI V3, this should be exchanged for a temporary session token.
   // For now, returning the API key directly for testing.
   logger.debug('assemblyai-token', 'Returning AssemblyAI API key (for temporary testing).');
-  res.json({ token: apiKey });
+  const settings = loadSettings();
+  res.json({
+    token: apiKey,
+    sampleRate: settings.sttSampleRate,
+    formattedFinals: settings.sttFormattedFinals
+  });
 });
 // --- End AssemblyAI Endpoint ---
 
 // +++ Start ElevenLabs TTS Streaming Endpoint +++
 app.post('/api/tts/elevenlabs-stream', async (req, res) => {
-    const { text, voice_id = 'D38z5RcWu1voky8WS1ja', model_id = 'eleven_flash_v2_5' } = req.body; // Default voice 'Rachel' and a common model
+    const settings = loadSettings();
+    const {
+        text,
+        voice_id = settings.ttsVoiceId,
+        model_id = settings.ttsModelId
+    } = req.body;
 
     if (!text) {
         logger.error('elevenlabs-tts', 'Text is required for TTS.');

--- a/src/tools/llmqueryopenai.js
+++ b/src/tools/llmqueryopenai.js
@@ -1,5 +1,6 @@
 const OpenAI = require('openai');
 const logger = require('../utils/logger');
+const { loadSettings } = require('../utils/settings');
 const fs = require('fs').promises;
 const path = require('path');
 const memory = require('../core/memory');
@@ -34,6 +35,12 @@ class LLMQueryOpenAITool {
             throw new Error('OPENAI_API_KEY environment variable is required');
         }
         this.client = new OpenAI();
+        const settings = loadSettings();
+        if (settings.queryModel) {
+            this.defaultModel = settings.queryModel;
+        } else if (settings.llmModel) {
+            this.defaultModel = settings.llmModel;
+        }
         logger.debug('llmqueryopenai.initialize', 'OpenAI client initialized');
     }
 
@@ -77,8 +84,10 @@ class LLMQueryOpenAITool {
             `;
 
             // Call OpenAI responses API
+            const settings = loadSettings();
+            const model = settings.queryModel || settings.llmModel || this.defaultModel;
             const response = await this.client.responses.create({
-                model: this.defaultModel,
+                model,
                 tools: [{ type: "web_search_preview" }],
                 input: input
             });

--- a/src/utils/llmClient.js
+++ b/src/utils/llmClient.js
@@ -1,6 +1,7 @@
 const { OpenAI } = require('openai');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const logger = require('./logger');
+const { loadSettings } = require('./settings');
 require('dotenv').config();
 
 class LLMClient {
@@ -29,14 +30,17 @@ class OpenAIClient extends LLMClient {
         }
 
         this.client = new OpenAI(options);
-        this.defaultModel = process.env.OPENAI_DEFAULT_MODEL;
+        const settings = loadSettings();
+        this.defaultModel = settings.llmModel || process.env.OPENAI_DEFAULT_MODEL;
         logger.debug('OpenAI Client', 'Client initialized', { client: this.client.baseURL });
     }
 
     async chat(messages, options = {}) {
-        logger.debug('OpenAI Client', 'Chatting', { messages, options, defaultModel: this.defaultModel });
+        const settings = loadSettings();
+        const model = options.model || settings.llmModel || this.defaultModel;
+        logger.debug('OpenAI Client', 'Chatting', { messages, options, model });
         const response = await this.client.chat.completions.create({
-            model: options.model || this.defaultModel,
+            model,
             messages,
             temperature: options.temperature || 0.7,
             max_tokens: options.max_tokens || 1000,

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const { DATA_DIR_PATH } = require('./dataDir');
+
+const SETTINGS_PATH = path.join(DATA_DIR_PATH, 'settings.json');
+
+const defaultSettings = {
+  // Base OpenAI model used if a specific one is not provided
+  llmModel: 'gpt-4.1',
+  // Optional specialised models for different subsystems
+  plannerModel: '',
+  evaluatorModel: '',
+  queryModel: '',
+  bubbleModel: '',
+  // Default ElevenLabs voice and model for TTS
+  ttsVoiceId: 'D38z5RcWu1voky8WS1ja', // "Rachel"
+  ttsModelId: 'eleven_flash_v2_5',
+  // Streaming STT defaults
+  sttSampleRate: 16000,
+  sttFormattedFinals: true
+};
+
+function loadSettings() {
+  try {
+    const data = fs.readFileSync(SETTINGS_PATH, 'utf8');
+    return { ...defaultSettings, ...JSON.parse(data) };
+  } catch (err) {
+    return { ...defaultSettings };
+  }
+}
+
+function saveSettings(settings) {
+  const data = { ...defaultSettings, ...settings };
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(data, null, 2));
+}
+
+module.exports = {
+  SETTINGS_PATH,
+  defaultSettings,
+  loadSettings,
+  saveSettings
+};

--- a/tests/assemblyToken.test.js
+++ b/tests/assemblyToken.test.js
@@ -1,0 +1,20 @@
+const request = require('supertest');
+const { app } = require('../src/index');
+const { SETTINGS_PATH, loadSettings, saveSettings } = require('../src/utils/settings');
+const fs = require('fs');
+
+describe('/api/assemblyai-token', () => {
+  afterEach(() => {
+    if (fs.existsSync(SETTINGS_PATH)) fs.unlinkSync(SETTINGS_PATH);
+  });
+
+  test('returns token and stt settings', async () => {
+    saveSettings({ sttSampleRate: 1234, sttFormattedFinals: false });
+    process.env.ASSEMBLY_AI_KEY = 'abc';
+    const res = await request(app).get('/api/assemblyai-token');
+    expect(res.status).toBe(200);
+    expect(res.body.sampleRate).toBe(1234);
+    expect(res.body.formattedFinals).toBe(false);
+    expect(res.body.token).toBe('abc');
+  });
+});

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const fs = require('fs');
+const { app } = require('../src/index');
+const { SETTINGS_PATH, loadSettings } = require('../src/utils/settings');
+
+describe('/settings page', () => {
+  afterEach(() => {
+    if (fs.existsSync(SETTINGS_PATH)) {
+      fs.unlinkSync(SETTINGS_PATH);
+    }
+  });
+
+  test('GET /settings returns page', async () => {
+    const res = await request(app).get('/settings');
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/App Settings/);
+  });
+
+  test('POST /settings saves file', async () => {
+    const res = await request(app)
+      .post('/settings')
+      .type('form')
+      .send({
+        llmModel: 'testLLM',
+        plannerModel: 'planModel',
+        evaluatorModel: 'evalModel',
+        queryModel: 'queryModel',
+        bubbleModel: 'bubbleModel',
+        ttsVoiceId: 'voiceX',
+        ttsModelId: 'modelY',
+        sttSampleRate: 8000,
+        sttFormattedFinals: 'on'
+      });
+    expect(res.status).toBe(302);
+    const saved = loadSettings();
+    expect(saved.llmModel).toBe('testLLM');
+    expect(saved.plannerModel).toBe('planModel');
+    expect(saved.evaluatorModel).toBe('evalModel');
+    expect(saved.queryModel).toBe('queryModel');
+    expect(saved.bubbleModel).toBe('bubbleModel');
+    expect(saved.ttsVoiceId).toBe('voiceX');
+    expect(saved.ttsModelId).toBe('modelY');
+    expect(saved.sttSampleRate).toBe(8000);
+    expect(saved.sttFormattedFinals).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extend settings with specific models per subsystem and STT parameters
- expose these fields on `/settings`
- return STT options from `/api/assemblyai-token`
- respect per-subsystem models in planner, evaluator and llmqueryopenai
- use token-provided STT settings in the client
- add tests for new settings and token endpoint
- add bubble model setting and revert frontend STT

## Testing
- `npm test --silent` *(fails: Cannot log after tests are done)*

------
https://chatgpt.com/codex/tasks/task_e_684565e9e3f0832895e3e3926e868c03