### PR TITLE
Improve settings defaults display

### DIFF
--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -20,23 +20,34 @@ const defaultSettings = {
   sttFormattedFinals: true
 };
 
-function loadSettings() {
+function loadRawSettings() {
   try {
     const data = fs.readFileSync(SETTINGS_PATH, 'utf8');
-    return { ...defaultSettings, ...JSON.parse(data) };
+    return JSON.parse(data);
   } catch (err) {
-    return { ...defaultSettings };
+    return {};
   }
 }
 
+function loadSettings() {
+  const raw = loadRawSettings();
+  const settings = { ...defaultSettings };
+  for (const key of Object.keys(defaultSettings)) {
+    if (raw[key] !== undefined && raw[key] !== '') {
+      settings[key] = raw[key];
+    }
+  }
+  return settings;
+}
+
 function saveSettings(settings) {
-  const data = { ...defaultSettings, ...settings };
-  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(data, null, 2));
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
 }
 
 module.exports = {
   SETTINGS_PATH,
   defaultSettings,
+  loadRawSettings,
   loadSettings,
   saveSettings
 };

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -43,4 +43,21 @@ describe('/settings page', () => {
     expect(saved.sttSampleRate).toBe(8000);
     expect(saved.sttFormattedFinals).toBe(true);
   });
+
+  test('POST /settings clears to default when blank', async () => {
+    // Set a custom model first
+    await request(app)
+      .post('/settings')
+      .type('form')
+      .send({ llmModel: 'custom-model' });
+
+    // Clear the model
+    await request(app)
+      .post('/settings')
+      .type('form')
+      .send({ llmModel: '' });
+
+    const saved = loadSettings();
+    expect(saved.llmModel).toBe('gpt-4.1');
+  });
 });


### PR DESCRIPTION
## Summary
- show actual effective defaults on settings page
- allow clearing a setting to restore default
- expose raw settings
- test that clearing resets to default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68457f6ad2d883288b20becac9d88e9d