### PR TITLE
Add clipboard copy and search in debug and subsystem modals

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -85,9 +85,10 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h3>Debug Output</h3>
+                <input type="text" class="filter-input" placeholder="Filter..." oninput="filterMessages('debug', this.value)">
                 <button onclick="toggleDebug()" class="close-button">&times;</button>
             </div>
-            <pre id="debug-output"></pre>
+            <div id="debug-output" class="modal-body"></div>
         </div>
     </div>
 
@@ -96,9 +97,10 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h3>Planner Output</h3>
+                <input type="text" class="filter-input" placeholder="Filter..." oninput="filterMessages('planner', this.value)">
                 <button onclick="toggleSubsystem('planner')" class="close-button">&times;</button>
             </div>
-            <pre id="planner-output"></pre>
+            <div id="planner-output" class="modal-body"></div>
         </div>
     </div>
 
@@ -107,9 +109,10 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h3>Coordinator Output</h3>
+                <input type="text" class="filter-input" placeholder="Filter..." oninput="filterMessages('coordinator', this.value)">
                 <button onclick="toggleSubsystem('coordinator')" class="close-button">&times;</button>
             </div>
-            <pre id="coordinator-output"></pre>
+            <div id="coordinator-output" class="modal-body"></div>
         </div>
     </div>
 
@@ -118,9 +121,10 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h3>Ego Output</h3>
+                <input type="text" class="filter-input" placeholder="Filter..." oninput="filterMessages('ego', this.value)">
                 <button onclick="toggleSubsystem('ego')" class="close-button">&times;</button>
             </div>
-            <pre id="ego-output"></pre>
+            <div id="ego-output" class="modal-body"></div>
         </div>
     </div>
 
@@ -129,9 +133,10 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h3>System Errors</h3>
+                <input type="text" class="filter-input" placeholder="Filter..." oninput="filterMessages('systemError', this.value)">
                 <button onclick="toggleSystemErrors()" class="close-button">&times;</button>
             </div>
-            <pre id="system-error-output"></pre>
+            <div id="system-error-output" class="modal-body"></div>
         </div>
     </div>
 

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1059,6 +1059,27 @@ header {
     transition: all 0.2s ease;
 }
 
+.copy-button {
+    background: #f5f5f5;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    padding: 2px 6px;
+    cursor: pointer;
+    font-size: 12px;
+    margin-left: 8px;
+}
+
+.copy-button:hover {
+    background: #e0e0e0;
+}
+
+.filter-input {
+    margin-left: auto;
+    margin-right: 10px;
+    padding: 4px 6px;
+    font-size: 12px;
+}
+
 .expand-all-button:hover,
 .collapse-all-button:hover {
     background: #e0e0e0;


### PR DESCRIPTION
## Summary
- add clipboard copy and keyword filter utilities
- store subsystem and debug messages with IDs
- add new debug output rendering with copy+filter support
- allow filtering and copying in planner, coordinator, ego and system error modals
- style copy button and filter input

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461d948f048328935e22939e1ed8e1