### PR TITLE
Fix reflection client usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "start": "node src/index.js",
         "dev": "DEBUG=llm-agent:* nodemon --watch src --watch public --ext js,html,css src/index.js",
-        "test": "jest",
+        "test": "jest --runInBand",
         "test:watch": "jest --watch",
         "query": "DEBUG=llm-agent:* node src/index.js"
     },

--- a/src/core/ego/index.js
+++ b/src/core/ego/index.js
@@ -551,13 +551,8 @@ class Ego {
             ];
 
             const settings = loadSettings();
-
-            if (!this.openaiClient || typeof this.openaiClient.chat !== 'function') {
-                logger.error('reflection', 'OpenAI client is not available');
-                return;
-            }
-
-            const response = await this.openaiClient.chat(messages, {
+            const openai = getOpenAIClient();
+            const response = await openai.chat(messages, {
                 model: settings.reflectionModel || settings.llmModel,
                 response_format: reflectionPrompts.REFLECTION_SCHEMA,
                 temperature: 0.7,

--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,8 @@ async function processInitialMessage() {
         const messages = await messagePromise;
         
         // Give a small delay to ensure all async operations complete
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        // Wait a bit longer so reflection has time to finish
+        await new Promise(resolve => setTimeout(resolve, 4000));
         
         // Log final message location if we got any messages
         if (messages.length > 0) {

--- a/tests/reflection.test.js
+++ b/tests/reflection.test.js
@@ -1,0 +1,13 @@
+const { execSync } = require('child_process');
+
+jest.setTimeout(120000);
+
+describe('reflection', () => {
+  test('completes reflection', () => {
+    const output = execSync('node src/index.js "Reflect on this"', {
+      env: process.env,
+      encoding: 'utf8'
+    });
+    expect(output).toMatch(/reflection: Starting reflection process/);
+  });
+});


### PR DESCRIPTION
## Summary
- get an OpenAI client within `reflection` before chatting
- extend wait time for reflection to complete
- add reflection unit test
- run tests sequentially

## Testing
- `npx jest --runInBand | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68462eb54f5c83288182f97a421f518c