### PR TITLE
Include short-term context in memory retrieval

### DIFF
--- a/agent_model.md
+++ b/agent_model.md
@@ -112,7 +112,7 @@ The Memory system allows the agent to retain and recall information.
 *   **Long-Term Memory (`long_term.txt`)**:
     *   Stores information intended for persistence across sessions.
     *   When storing, an LLM analyzes the content to generate a summary and relevant tags (`prompts.MEMORY_ANALYSIS_PROMPT`).
-    *   When retrieving, an LLM selects the most relevant memories based on the query (`prompts.MEMORY_RETRIEVAL_PROMPT`).
+    *   When retrieving, an LLM selects the most relevant memories based on the query (`prompts.MEMORY_RETRIEVAL_PROMPT`). If short-term memory is available, it is appended to the question so retrieval considers the recent conversation context.
 *   **Event Emission**: Emits `subsystemMessage` events (with module ID 'ego') for memory operations like retrieval, analysis, and categorization, providing transparency into its workings.
 
 ## 9. Event System (`src/utils/eventEmitter.js`)

--- a/src/core/ego/index.js
+++ b/src/core/ego/index.js
@@ -138,7 +138,7 @@ class Ego {
             await memory.storeShortTerm('User message', externalUserMessageToInternal);
 
             const shortTermMemory = await memory.retrieveShortTerm();
-            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', message);
+            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', message, shortTermMemory);
             const enrichedMessage = {
                 original_message: externalUserMessageToInternal,
                 context: {
@@ -332,7 +332,7 @@ class Ego {
         logger.debug('handleBubble', 'Handling bubble', { result, extraInstruction });
         try {
             const shortTermMemory = await memory.retrieveShortTerm();
-            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', 'retrieve anything relevant to responding to the user');
+            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', 'retrieve anything relevant to responding to the user', shortTermMemory);
 
             // Prepare the message for the ego
             let message = '';

--- a/src/core/planner/index.js
+++ b/src/core/planner/index.js
@@ -67,7 +67,7 @@ async function planner(enrichedMessage, client = null) {
         if (!longTermMemory) {
             // Create a more specific query based on the user's message
             const memoryQuery = `Retrieve any information relevant to: ${enrichedMessage.original_message}`;
-            longTermMemory = (await memory.retrieveLongTerm('ego', memoryQuery)) || '';
+            longTermMemory = (await memory.retrieveLongTerm('ego', memoryQuery, shortTermMemory)) || '';
             logger.debug('memory', 'Retrieved long-term memory directly:', {
                 length: longTermMemory.length,
                 query: memoryQuery

--- a/src/tools/llmquery.js
+++ b/src/tools/llmquery.js
@@ -53,7 +53,7 @@ class LLMQueryTool {
         }
 
         const shortTermMemory = await memory.retrieveShortTerm();
-        const longTermRelevantMemory = await memory.retrieveLongTerm('ego', query);
+        const longTermRelevantMemory = await memory.retrieveLongTerm('ego', query, shortTermMemory);
 
         let userPrompt = `
         ${query}

--- a/src/tools/llmqueryopenai.js
+++ b/src/tools/llmqueryopenai.js
@@ -70,8 +70,8 @@ class LLMQueryOpenAITool {
         try {
             // Retrieve memory
             const shortTermMemory = await memory.retrieveShortTerm();
-            // Pass the actual user query to the retrieveLongTerm function for better context
-            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', queryParam.value);
+            // Pass the actual user query and conversation context to the retrieveLongTerm function for better context
+            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', queryParam.value, shortTermMemory);
 
             // Construct input with memory context
             const input = `

--- a/src/tools/longTermMemory.js
+++ b/src/tools/longTermMemory.js
@@ -78,10 +78,11 @@ class LongTermMemoryTool {
             throw new Error('Missing required parameter: question');
         }
         try {
-            const result = await memory.retrieveLongTerm(contextParam ? contextParam.value : null, questionParam.value);
+            const shortTermMemory = await memory.retrieveShortTerm();
+            const result = await memory.retrieveLongTerm(contextParam ? contextParam.value : null, questionParam.value, shortTermMemory);
             return {
                 status: 'success',
-                result: result.analysis
+                result: result
             };
         } catch (error) {
             return {


### PR DESCRIPTION
## Summary
- add optional short-term context to `retrieveLongTerm`
- pass short-term memory when retrieving long-term memory in ego, planner and tools
- document that retrieval uses recent conversation context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68462fa20ba48328b52decd90da0bf89