### PR TITLE
Add configurable token limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The application includes a comprehensive system error tracking mechanism:
 
 1. **Error Collection**: All errors across modules are captured with:
    - Module name and location
+   - Specific component that triggered the error (e.g., which module exceeded a token limit)
    - Full error message and stack trace
    - Error context and status
    - Timestamp of occurrence
@@ -543,6 +544,9 @@ The script will show test results and help catch any issues early.
    docker-compose up --build
    ```
 
+4. After the first run, edit `data/settings.json` to customize runtime options.
+   Set `maxTokens` to control the default token limit for LLM responses.
+
 ### Testing
 Run the test suite:
 ```bash
@@ -841,6 +845,7 @@ The `resetMemory` function allows the user to reset the current memory by transf
 
 ### Changes in Functionality
 - The `retrieveLongTerm` method now defaults the `context` parameter to 'ego' if it is null, ensuring consistent behavior when retrieving long-term memory.
+- When retrieving, any available short-term memory is appended to the question so that long-term memory results account for recent conversation context.
 
 ## Updates
 

--- a/agent_model.md
+++ b/agent_model.md
@@ -112,7 +112,7 @@ The Memory system allows the agent to retain and recall information.
 *   **Long-Term Memory (`long_term.txt`)**:
     *   Stores information intended for persistence across sessions.
     *   When storing, an LLM analyzes the content to generate a summary and relevant tags (`prompts.MEMORY_ANALYSIS_PROMPT`).
-    *   When retrieving, an LLM selects the most relevant memories based on the query (`prompts.MEMORY_RETRIEVAL_PROMPT`).
+    *   When retrieving, an LLM selects the most relevant memories based on the query (`prompts.MEMORY_RETRIEVAL_PROMPT`). If short-term memory is available, it is appended to the question so retrieval considers the recent conversation context.
 *   **Event Emission**: Emits `subsystemMessage` events (with module ID 'ego') for memory operations like retrieval, analysis, and categorization, providing transparency into its workings.
 
 ## 9. Event System (`src/utils/eventEmitter.js`)

--- a/src/core/ego/index.js
+++ b/src/core/ego/index.js
@@ -138,7 +138,7 @@ class Ego {
             await memory.storeShortTerm('User message', externalUserMessageToInternal);
 
             const shortTermMemory = await memory.retrieveShortTerm();
-            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', message);
+            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', message, shortTermMemory);
             const enrichedMessage = {
                 original_message: externalUserMessageToInternal,
                 context: {
@@ -332,7 +332,7 @@ class Ego {
         logger.debug('handleBubble', 'Handling bubble', { result, extraInstruction });
         try {
             const shortTermMemory = await memory.retrieveShortTerm();
-            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', 'retrieve anything relevant to responding to the user');
+            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', 'retrieve anything relevant to responding to the user', shortTermMemory);
 
             // Prepare the message for the ego
             let message = '';
@@ -556,7 +556,7 @@ class Ego {
                 model: settings.reflectionModel || settings.llmModel,
                 response_format: reflectionPrompts.REFLECTION_SCHEMA,
                 temperature: 0.7,
-                max_tokens: 1000
+                max_tokens: settings.maxTokens || 1000
             });
 
             let reflectionResults;

--- a/src/core/evaluator/index.js
+++ b/src/core/evaluator/index.js
@@ -82,7 +82,7 @@ async function getEvaluation(prompt) {
         model: settings.evaluatorModel || settings.llmModel,
         response_format: prompts.EVALUATION_SCHEMA,
         temperature: 0.7,
-        max_tokens: 1000
+        max_tokens: settings.maxTokens || 1000
     });
 
     return response.content;

--- a/src/core/planner/index.js
+++ b/src/core/planner/index.js
@@ -67,7 +67,7 @@ async function planner(enrichedMessage, client = null) {
         if (!longTermMemory) {
             // Create a more specific query based on the user's message
             const memoryQuery = `Retrieve any information relevant to: ${enrichedMessage.original_message}`;
-            longTermMemory = (await memory.retrieveLongTerm('ego', memoryQuery)) || '';
+            longTermMemory = (await memory.retrieveLongTerm('ego', memoryQuery, shortTermMemory)) || '';
             logger.debug('memory', 'Retrieved long-term memory directly:', {
                 length: longTermMemory.length,
                 query: memoryQuery

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ app.get('/settings', (req, res) => {
   <label>Query Model:<input type="text" name="queryModel" value="${raw.queryModel ?? ''}" placeholder="${defaults.queryModel || baseModel}" /></label><br/>
   <label>Bubble Model:<input type="text" name="bubbleModel" value="${raw.bubbleModel ?? ''}" placeholder="${defaults.bubbleModel || baseModel}" /></label><br/>
   <label>Reflection Model:<input type="text" name="reflectionModel" value="${raw.reflectionModel ?? ''}" placeholder="${defaults.reflectionModel || baseModel}" /></label><br/>
+  <label>LLM Max Tokens:<input type="number" name="maxTokens" value="${raw.maxTokens ?? ''}" placeholder="${defaults.maxTokens}" /></label><br/>
   <label>TTS Voice ID:<input type="text" name="ttsVoiceId" value="${raw.ttsVoiceId ?? ''}" placeholder="${defaults.ttsVoiceId}" /></label><br/>
   <label>TTS Model ID:<input type="text" name="ttsModelId" value="${raw.ttsModelId ?? ''}" placeholder="${defaults.ttsModelId}" /></label><br/>
   <label>STT Sample Rate:<input type="number" name="sttSampleRate" value="${raw.sttSampleRate ?? ''}" placeholder="${defaults.sttSampleRate}" /></label><br/>
@@ -54,6 +55,7 @@ app.post('/settings', (req, res) => {
     assign('queryModel');
     assign('bubbleModel');
     assign('reflectionModel');
+    assign('maxTokens', v => parseInt(v, 10));
     assign('ttsVoiceId');
     assign('ttsModelId');
     assign('sttSampleRate', v => parseInt(v, 10));

--- a/src/tools/llmquery.js
+++ b/src/tools/llmquery.js
@@ -1,6 +1,7 @@
 const logger = require('../utils/logger.js');
 const memory = require('../core/memory');
 const { getOpenAIClient } = require("../utils/openaiClient.js");
+const { loadSettings } = require("../utils/settings");
 const { validateToolResponse } = require('../validation/toolValidator');
 
 /** @implements {import('../types/tool').Tool} */
@@ -53,7 +54,7 @@ class LLMQueryTool {
         }
 
         const shortTermMemory = await memory.retrieveShortTerm();
-        const longTermRelevantMemory = await memory.retrieveLongTerm('ego', query);
+        const longTermRelevantMemory = await memory.retrieveLongTerm('ego', query, shortTermMemory);
 
         let userPrompt = `
         ${query}
@@ -73,9 +74,10 @@ class LLMQueryTool {
 
         logger.debug('llmquery', 'messages being sent to OpenAI', { messages }, false);
         const openai = getOpenAIClient();
+        const settings = loadSettings();
         const response = await openai.chat(messages, {
             temperature: 0.7,
-            max_tokens: 1000
+            max_tokens: settings.maxTokens || 1000
         });
 
         logger.debug('llmquery', 'OpenAI response', { response }, false);

--- a/src/tools/llmqueryopenai.js
+++ b/src/tools/llmqueryopenai.js
@@ -70,8 +70,8 @@ class LLMQueryOpenAITool {
         try {
             // Retrieve memory
             const shortTermMemory = await memory.retrieveShortTerm();
-            // Pass the actual user query to the retrieveLongTerm function for better context
-            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', queryParam.value);
+            // Pass the actual user query and conversation context to the retrieveLongTerm function for better context
+            const longTermRelevantMemory = await memory.retrieveLongTerm('ego', queryParam.value, shortTermMemory);
 
             // Construct input with memory context
             const input = `

--- a/src/tools/longTermMemory.js
+++ b/src/tools/longTermMemory.js
@@ -78,10 +78,11 @@ class LongTermMemoryTool {
             throw new Error('Missing required parameter: question');
         }
         try {
-            const result = await memory.retrieveLongTerm(contextParam ? contextParam.value : null, questionParam.value);
+            const shortTermMemory = await memory.retrieveShortTerm();
+            const result = await memory.retrieveLongTerm(contextParam ? contextParam.value : null, questionParam.value, shortTermMemory);
             return {
                 status: 'success',
-                result: result.analysis
+                result: result
             };
         } catch (error) {
             return {

--- a/src/tools/planUpdater.js
+++ b/src/tools/planUpdater.js
@@ -1,6 +1,7 @@
 const logger = require('../utils/logger.js');
 const memory = require('../core/memory');
 const { getOpenAIClient } = require("../utils/openaiClient.js");
+const { loadSettings } = require("../utils/settings");
 
 class PlanUpdaterTool {
     constructor() {
@@ -64,6 +65,7 @@ Remember:
 
         try {
             const openai = getOpenAIClient();
+            const settings = loadSettings();
             const response = await openai.chat(messages, {
                 response_format: {
                     type: "json_schema",
@@ -124,7 +126,7 @@ Remember:
                     }
                 },
                 temperature: 0.7,
-                max_tokens: 1000
+                max_tokens: settings.maxTokens || 1000
             });
 
             const evaluation = JSON.parse(response.content);

--- a/src/utils/llmClient.js
+++ b/src/utils/llmClient.js
@@ -38,12 +38,13 @@ class OpenAIClient extends LLMClient {
     async chat(messages, options = {}) {
         const settings = loadSettings();
         const model = options.model || settings.llmModel || this.defaultModel;
-        logger.debug('OpenAI Client', 'Chatting', { messages, options, model });
+        const maxTokens = options.max_tokens || settings.maxTokens || 1000;
+        logger.debug('OpenAI Client', 'Chatting', { messages, options, model, maxTokens });
         const response = await this.client.chat.completions.create({
             model,
             messages,
             temperature: options.temperature || 0.7,
-            max_tokens: options.max_tokens || 1000,
+            max_tokens: maxTokens,
             response_format: options.response_format
         });
         return {

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -13,6 +13,8 @@ const defaultSettings = {
   queryModel: '',
   bubbleModel: '',
   reflectionModel: '',
+  // Default maximum tokens for LLM responses
+  maxTokens: 1000,
   // Default ElevenLabs voice and model for TTS
   ttsVoiceId: 'D38z5RcWu1voky8WS1ja', // "Rachel"
   ttsModelId: 'eleven_flash_v2_5',

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -10,6 +10,11 @@ describe('/settings page', () => {
     }
   });
 
+  test('default settings provide maxTokens', () => {
+    const settings = loadSettings();
+    expect(settings.maxTokens).toBe(1000);
+  });
+
   test('GET /settings returns page', async () => {
     const res = await request(app).get('/settings');
     expect(res.status).toBe(200);
@@ -26,6 +31,7 @@ describe('/settings page', () => {
         evaluatorModel: 'evalModel',
         queryModel: 'queryModel',
         bubbleModel: 'bubbleModel',
+        maxTokens: 1500,
         ttsVoiceId: 'voiceX',
         ttsModelId: 'modelY',
         sttSampleRate: 8000,
@@ -38,6 +44,7 @@ describe('/settings page', () => {
     expect(saved.evaluatorModel).toBe('evalModel');
     expect(saved.queryModel).toBe('queryModel');
     expect(saved.bubbleModel).toBe('bubbleModel');
+    expect(saved.maxTokens).toBe(1500);
     expect(saved.ttsVoiceId).toBe('voiceX');
     expect(saved.ttsModelId).toBe('modelY');
     expect(saved.sttSampleRate).toBe(8000);
@@ -59,5 +66,6 @@ describe('/settings page', () => {
 
     const saved = loadSettings();
     expect(saved.llmModel).toBe('gpt-4.1');
+    expect(saved.maxTokens).toBe(1000);
   });
 });


### PR DESCRIPTION
## Summary
- expose `maxTokens` in settings and update settings page
- use settings value as default for all 1000-token LLM calls
- document how system errors indicate token limit issues
- describe customizing token limits in README
- test new settings property
- restore short-term memory context when retrieving long-term memory
- clarify README about short-term memory use during retrieval

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68461d41f5e88328976c72595ae05c01