### PR TITLE
Improve reflection with long term memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,14 +822,15 @@ Content here
 
 ### Reflection Process
 
-The reflection step now examines the most recent short‑term memory and uses the LLM to generate insights, lessons learned, and follow‑up questions. Each reflection is based on the current conversation history and the results are stored in long‑term memory for later use.
+The reflection step now examines the most recent short‑term memory **and** any relevant long‑term memory describing how the agent believes it works. This includes operational guidelines and the agent's own internal model. The combined context is sent to the LLM to generate insights, lessons learned, follow‑up questions, and actionable directives. These directives are stored as long‑term memories so the agent can adapt its future behavior based on past interactions.
 
 Example reflection output:
 ```
-{
+{ 
   "insights": [ ... ],
   "lessons_learned": [ ... ],
-  "follow_up_questions": [ ... ]
+  "follow_up_questions": [ ... ],
+  "directives": [ ... ]
 }
 ```
 

--- a/src/core/ego/reflection-prompts.js
+++ b/src/core/ego/reflection-prompts.js
@@ -3,6 +3,7 @@
  * 
  * Template variables:
  * - {{short_term_memory}}: The short-term memory content to be analyzed
+ * - {{long_term_memory}}: Relevant long-term memory about how the agent thinks it works
  */
 
 // System prompt for reflection
@@ -20,6 +21,10 @@ Keep the analysis objective and constructive, focusing on lessons that will impr
 const REFLECTION_USER = `Analyze the following short-term memory log of the conversation between the user and the agent:
 
 {{short_term_memory}}
+
+Relevant long-term memory about how the agent thinks it works and its internal model:
+
+{{long_term_memory}}
 
 Provide a thoughtful reflection that includes:
 1. Key moments where the user clarified, refined or corrected the agent
@@ -45,6 +50,12 @@ Format your response as a JSON object with the following structure:
   ],
   "follow_up_questions": [
     "string" // Questions to ask in future interactions
+  ],
+  "directives": [
+    {
+      "instruction": "string", // Instruction or memory to store
+      "reason": "string" // Why this directive is important
+    }
   ]
 }`;
 
@@ -99,9 +110,21 @@ const REFLECTION_SCHEMA = {
           "items": {
             "type": "string"
           }
+        },
+        "directives": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "instruction": { "type": "string" },
+              "reason": { "type": "string" }
+            },
+            "required": ["instruction", "reason"],
+            "additionalProperties": false
+          }
         }
       },
-      "required": ["insights", "lessons_learned", "follow_up_questions"],
+      "required": ["insights", "lessons_learned", "follow_up_questions", "directives"],
       "additionalProperties": false
     },
     "strict": true


### PR DESCRIPTION
## Summary
- include long term memory in the reflection prompt
- allow reflection to produce actionable directives
- store those directives in long term memory
- document updated reflection behavior
- refine long term memory query to pull everything the agent knows about its operations

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846546441e88328a1e118179ffb1fbc