### PR TITLE
Add GPT nano utterance check

### DIFF
--- a/tests/utteranceCheck.test.js
+++ b/tests/utteranceCheck.test.js
@@ -1,0 +1,12 @@
+const request = require('supertest');
+const { app } = require('../src/index');
+
+describe('/api/utterance-check', () => {
+  test('returns boolean result', async () => {
+    const res = await request(app)
+      .post('/api/utterance-check')
+      .send({ text: 'Is this a full sentence?' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('complete');
+  });
+});


### PR DESCRIPTION
## Summary
- add /api/utterance-check endpoint that uses GPT-4o-mini
- validate STT end_of_turn segments with the new endpoint in `chat.js`
- add test for the utterance check API
- use GPT-4.1-nano for utterance checks
- clear chat input after auto send

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846531021f48328b7bd81bdec7656a4