### PR TITLE
Add GPT nano utterance check

### DIFF
--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -13,6 +13,7 @@ const defaultSettings = {
   queryModel: '',
   bubbleModel: '',
   reflectionModel: '',
+  utteranceCheckModel: 'gpt-4.1-nano',
   // Default maximum tokens for LLM responses
   maxTokens: 1000,
   // Default ElevenLabs voice and model for TTS

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -31,6 +31,7 @@ describe('/settings page', () => {
         evaluatorModel: 'evalModel',
         queryModel: 'queryModel',
         bubbleModel: 'bubbleModel',
+        utteranceCheckModel: 'nano-model',
         maxTokens: 1500,
         ttsVoiceId: 'voiceX',
         ttsModelId: 'modelY',
@@ -44,6 +45,7 @@ describe('/settings page', () => {
     expect(saved.evaluatorModel).toBe('evalModel');
     expect(saved.queryModel).toBe('queryModel');
     expect(saved.bubbleModel).toBe('bubbleModel');
+    expect(saved.utteranceCheckModel).toBe('nano-model');
     expect(saved.maxTokens).toBe(1500);
     expect(saved.ttsVoiceId).toBe('voiceX');
     expect(saved.ttsModelId).toBe('modelY');

--- a/tests/utteranceCheck.test.js
+++ b/tests/utteranceCheck.test.js
@@ -1,0 +1,12 @@
+const request = require('supertest');
+const { app } = require('../src/index');
+
+describe('/api/utterance-check', () => {
+  test('returns boolean result', async () => {
+    const res = await request(app)
+      .post('/api/utterance-check')
+      .send({ text: 'Is this a full sentence?' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('complete');
+  });
+});


### PR DESCRIPTION
## Summary
- add /api/utterance-check endpoint that uses GPT-4o-mini
- validate STT end_of_turn segments with the new endpoint in `chat.js`
- add test for the utterance check API
- use GPT-4.1-nano for utterance checks
- clear chat input after auto send
- make utterance check model configurable in settings

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6846531021f48328b7bd81bdec7656a4