### PR TITLE
Enable prompt override system

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,14 @@ To add a new personality:
 3. The personality will be automatically loaded on next startup
 4. If it's the only personality file present, it will become the default
 
+### Prompt Overrides
+
+You can override any built-in prompt template by placing a text file in
+`data/prompts/<module>/<PROMPT_NAME>.txt`. When `usePromptOverrides` is enabled
+in `data/settings.json`, the system will load these files instead of the baked
+in versions. If an override is missing or fails to load, the default prompt will
+be used automatically.
+
 ### System Architecture
 
 The system is designed with clear separation of concerns:

--- a/src/core/ego/prompts.js
+++ b/src/core/ego/prompts.js
@@ -9,8 +9,11 @@
  * - {{original_message}}: The original user message
  */
 
+const { loadPrompt } = require('../../utils/promptManager');
+const MODULE = 'ego';
+
 // System prompt for the ego
-const EGO_SYSTEM = `You are {{identity}}, an AI assistant with the following capabilities:
+const EGO_SYSTEM_DEFAULT = `You are {{identity}}, an AI assistant with the following capabilities:
         - Conversation: You can engage in natural language dialogue. I always refer to the user in the second person.
         - Task Execution: You can help with file operations and other tasks
         
@@ -37,9 +40,10 @@ const EGO_SYSTEM = `You are {{identity}}, an AI assistant with the following cap
         - Always respond from the perspective of this assistant conversing with the user
         - From the user's perspective, you are a real entity so expect questions about who and what you are
         `;
+const EGO_SYSTEM = loadPrompt(MODULE, 'EGO_SYSTEM', EGO_SYSTEM_DEFAULT);
 
 // User prompt for the ego
-const EGO_USER = `Respond to the following request in your personality's style. 
+const EGO_USER_DEFAULT = `Respond to the following request in your personality's style.
      Format your response as a JSON object with 'chat' and 'canvas' fields.
      
      For the 'chat' field:
@@ -57,15 +61,17 @@ const EGO_USER = `Respond to the following request in your personality's style.
      - Should be a complete response that could stand alone
      
      Request to respond to: {{message}}`;
+const EGO_USER = loadPrompt(MODULE, 'EGO_USER', EGO_USER_DEFAULT);
 
 // Extra instruction for the ego when handling execution results
 // Template variables:
 // - {{original_message}}: The original user message that triggered the execution
-const EGO_EXECUTION_INSTRUCTION = `Your original request was: "{{original_message}}"
+const EGO_EXECUTION_INSTRUCTION_DEFAULT = `Your original request was: "{{original_message}}"
 
 As long as the evaluation score was greater than 80, respond naturally to the original request using the execution results. If less than 80, include a summary of the analysis and suggestions for how to improve.
 
 Remember to maintain conversation continuity with the original request.`;
+const EGO_EXECUTION_INSTRUCTION = loadPrompt(MODULE, 'EGO_EXECUTION_INSTRUCTION', EGO_EXECUTION_INSTRUCTION_DEFAULT);
 
 module.exports = {
   EGO_SYSTEM,

--- a/src/core/evaluator/prompts.js
+++ b/src/core/evaluator/prompts.js
@@ -7,11 +7,15 @@
  * - {{executionResult}}: The JSON representation of the execution results
  */
 
+const { loadPrompt } = require('../../utils/promptManager');
+const MODULE = 'evaluator';
+
 // System prompt for the evaluator
-const EVALUATOR_SYSTEM = "You are an expert evaluator that assesses task execution results. You must respond with valid JSON. Always respond in valid JSON format.";
+const EVALUATOR_SYSTEM_DEFAULT = "You are an expert evaluator that assesses task execution results. You must respond with valid JSON. Always respond in valid JSON format.";
+const EVALUATOR_SYSTEM = loadPrompt(MODULE, 'EVALUATOR_SYSTEM', EVALUATOR_SYSTEM_DEFAULT);
 
 // User prompt for the evaluator
-const EVALUATOR_USER = `You are an expert evaluator assessing if a task's execution matches its intended outcome.
+const EVALUATOR_USER_DEFAULT = `You are an expert evaluator assessing if a task's execution matches its intended outcome.
 
 Original Request:
 {{originalRequest}}
@@ -37,6 +41,7 @@ Format your response as JSON:
     "analysis": "detailed analysis here",
     "recommendations": ["recommendation1", "recommendation2", ...]
 }`;
+const EVALUATOR_USER = loadPrompt(MODULE, 'EVALUATOR_USER', EVALUATOR_USER_DEFAULT);
 
 // JSON schema for evaluation response
 const EVALUATION_SCHEMA = {

--- a/src/core/memory/prompts.js
+++ b/src/core/memory/prompts.js
@@ -7,18 +7,23 @@
  * - {{memories}}: The list of memories to search through (for RETRIEVE_MEMORY_USER)
  */
 
-// Prompt for categorizing long-term memory
-const CATEGORIZE_MEMORY_SYSTEM = "You are a categorization assistant. You must respond with valid JSON.";
+const { loadPrompt } = require('../../utils/promptManager');
+const MODULE = 'memory';
 
-const CATEGORIZE_MEMORY_USER = `Categorize the following data into a one-word description. Unless there is an explicit category, categorize it as one of the following: 
+// Prompt for categorizing long-term memory
+const CATEGORIZE_MEMORY_SYSTEM_DEFAULT = "You are a categorization assistant. You must respond with valid JSON.";
+const CATEGORIZE_MEMORY_SYSTEM = loadPrompt(MODULE, 'CATEGORIZE_MEMORY_SYSTEM', CATEGORIZE_MEMORY_SYSTEM_DEFAULT);
+
+const CATEGORIZE_MEMORY_USER_DEFAULT = `Categorize the following data into a one-word description. Unless there is an explicit category, categorize it as one of the following:
         - ego (conversation style preferences, user preferences) This is also the default category
         - execution (skills / tool usage)
         - planning (how to structure plans)
         - evaluation (how to evaluate plans)
         If it doesn't fit, suggest a unique, single word category: {{data}}`;
+const CATEGORIZE_MEMORY_USER = loadPrompt(MODULE, 'CATEGORIZE_MEMORY_USER', CATEGORIZE_MEMORY_USER_DEFAULT);
 
 // Prompt for retrieving relevant memories
-const RETRIEVE_MEMORY_SYSTEM = `You are a memory retrieval assistant. Find the most relevant memories to answer the question.
+const RETRIEVE_MEMORY_SYSTEM_DEFAULT = `You are a memory retrieval assistant. Find the most relevant memories to answer the question.
 
 You will be provided with the entire memory database content. Your job is to scan through it and identify any information that would be relevant to answering the user's question.
 
@@ -29,8 +34,9 @@ Pay special attention to:
 4. Location preferences, formatting preferences, or other user-specific settings
 5. Tags in the memory entries that relate to the query topic (e.g., 'weather', 'temperature', etc.)
 6. Implicit relationships between the query and stored memories (e.g., if query is about weather, look for location preferences)`;
+const RETRIEVE_MEMORY_SYSTEM = loadPrompt(MODULE, 'RETRIEVE_MEMORY_SYSTEM', RETRIEVE_MEMORY_SYSTEM_DEFAULT);
 
-const RETRIEVE_MEMORY_USER = `Given the following memory database content and a question, extract and return only the information that is most relevant to answering the question.
+const RETRIEVE_MEMORY_USER_DEFAULT = `Given the following memory database content and a question, extract and return only the information that is most relevant to answering the question.
     
 Question: "{{question}}"
     
@@ -47,6 +53,7 @@ Important guidelines:
 7. Always check for default preferences related to the query topic
 8. Consider implicit relationships (e.g., weather queries need location preferences)
 9. Be thorough - missing relevant information will impact the quality of responses`;
+const RETRIEVE_MEMORY_USER = loadPrompt(MODULE, 'RETRIEVE_MEMORY_USER', RETRIEVE_MEMORY_USER_DEFAULT);
 
 // JSON schema for categorization response
 const CATEGORIZE_SCHEMA = {
@@ -76,7 +83,7 @@ const CATEGORIZE_SCHEMA = {
 };
 
 // Prompt for consolidating long-term memory
-const CONSOLIDATE_MEMORY_SYSTEM = `You are a memory optimization assistant. Your task is to carefully consolidate a set of memories by:
+const CONSOLIDATE_MEMORY_SYSTEM_DEFAULT = `You are a memory optimization assistant. Your task is to carefully consolidate a set of memories by:
 1. Removing exact and near-duplicate memories (keeping the newest version based on timestamp)
 2. Pruning low-value content like process markers, debugging info, and metadata that won't be useful for future queries
 3. Merging memories that convey the same material facts or understanding about the SAME SPECIFIC TOPIC, even if the wording is different
@@ -87,8 +94,9 @@ const CONSOLIDATE_MEMORY_SYSTEM = `You are a memory optimization assistant. Your
 8. Preserving all substantive information that would be valuable for future retrieval
 
 You must respond with a JSON object containing an array of consolidated memory objects.`;
+const CONSOLIDATE_MEMORY_SYSTEM = loadPrompt(MODULE, 'CONSOLIDATE_MEMORY_SYSTEM', CONSOLIDATE_MEMORY_SYSTEM_DEFAULT);
 
-const CONSOLIDATE_MEMORY_USER = `Analyze and consolidate the following memories:
+const CONSOLIDATE_MEMORY_USER_DEFAULT = `Analyze and consolidate the following memories:
 
 {{memories}}
 
@@ -114,6 +122,7 @@ Return a JSON object with a 'memories' array containing the consolidated memory 
     }
   ]
 }`;
+const CONSOLIDATE_MEMORY_USER = loadPrompt(MODULE, 'CONSOLIDATE_MEMORY_USER', CONSOLIDATE_MEMORY_USER_DEFAULT);
 
 // JSON schema for consolidation response
 const CONSOLIDATE_SCHEMA = {

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,13 @@ app.get('/settings', (req, res) => {
     const defaults = defaultSettings;
     const baseModel = defaults.llmModel;
     const html = `<!DOCTYPE html>
-<html><head><title>Settings</title></head><body>
+<html><head><title>Settings</title>
+<style>.tab{display:none;} .tab.active{display:block;}</style>
+<script>function showTab(id){document.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));document.getElementById(id).classList.add('active');}</script>
+</head><body>
 <h1>App Settings</h1>
+<div><button onclick="showTab('general')">General</button><button onclick="showTab('prompts')">Prompts</button></div>
+<div id="general" class="tab active">
 <form method="POST" action="/settings">
   <label>LLM Model:<input type="text" name="llmModel" value="${raw.llmModel ?? ''}" placeholder="${defaults.llmModel}" /></label><br/>
   <label>Planner Model:<input type="text" name="plannerModel" value="${raw.plannerModel ?? ''}" placeholder="${defaults.plannerModel || baseModel}" /></label><br/>
@@ -37,8 +42,13 @@ app.get('/settings', (req, res) => {
   <label>STT Sample Rate:<input type="number" name="sttSampleRate" value="${raw.sttSampleRate ?? ''}" placeholder="${defaults.sttSampleRate}" /></label><br/>
   <label>STT Formatted Finals:<input type="checkbox" name="sttFormattedFinals" ${effective.sttFormattedFinals ? 'checked' : ''} /></label><br/>
   <label>Auto-send Delay (ms):<input type="number" name="autoSendDelayMs" value="${raw.autoSendDelayMs ?? ''}" placeholder="${defaults.autoSendDelayMs}" /></label><br/>
+  <label>Use Prompt Overrides:<input type="checkbox" name="usePromptOverrides" ${effective.usePromptOverrides ? 'checked' : ''} /></label><br/>
   <button type="submit">Save</button>
 </form>
+</div>
+<div id="prompts" class="tab">
+  <p>Place prompt override files in <code>data/prompts/&lt;module&gt;/&lt;PROMPTNAME&gt;.txt</code>.</p>
+</div>
 </body></html>`;
     res.send(html);
 });
@@ -64,6 +74,7 @@ app.post('/settings', (req, res) => {
     assign('sttSampleRate', v => parseInt(v, 10));
     newSettings.sttFormattedFinals = req.body.sttFormattedFinals ? true : false;
     assign('autoSendDelayMs', v => parseInt(v, 10));
+    newSettings.usePromptOverrides = req.body.usePromptOverrides ? true : false;
 
     saveSettings(newSettings);
     res.redirect('/settings');

--- a/src/utils/promptManager.js
+++ b/src/utils/promptManager.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const { DATA_DIR_PATH } = require('./dataDir');
+const { loadSettings } = require('./settings');
+const logger = require('./logger');
+
+function loadPrompt(moduleName, promptName, defaultValue) {
+    const settings = loadSettings();
+    if (settings.usePromptOverrides === false) {
+        return defaultValue;
+    }
+
+    const overridePath = path.join(DATA_DIR_PATH, 'prompts', moduleName, `${promptName}.txt`);
+    try {
+        if (fs.existsSync(overridePath)) {
+            const content = fs.readFileSync(overridePath, 'utf8');
+            logger.debug('PromptManager', `Loaded override for ${moduleName}/${promptName}`);
+            return content.trim();
+        }
+    } catch (err) {
+        logger.error('PromptManager', `Failed loading override for ${moduleName}/${promptName}:`, err);
+    }
+    return defaultValue;
+}
+
+module.exports = { loadPrompt };

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -23,7 +23,9 @@ const defaultSettings = {
   sttSampleRate: 16000,
   sttFormattedFinals: true,
   // Delay before auto-sending speech input (ms)
-  autoSendDelayMs: 2000
+  autoSendDelayMs: 2000,
+  // Whether to load prompt overrides from the data directory
+  usePromptOverrides: true
 };
 
 function loadRawSettings() {

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -14,6 +14,7 @@ describe('/settings page', () => {
     const settings = loadSettings();
     expect(settings.maxTokens).toBe(1000);
     expect(settings.autoSendDelayMs).toBe(2000);
+    expect(settings.usePromptOverrides).toBe(true);
   });
 
   test('GET /settings returns page', async () => {
@@ -38,7 +39,8 @@ describe('/settings page', () => {
         ttsModelId: 'modelY',
         sttSampleRate: 8000,
         sttFormattedFinals: 'on',
-        autoSendDelayMs: 3000
+        autoSendDelayMs: 3000,
+        usePromptOverrides: 'on'
       });
     expect(res.status).toBe(302);
     const saved = loadSettings();
@@ -54,6 +56,7 @@ describe('/settings page', () => {
     expect(saved.sttSampleRate).toBe(8000);
     expect(saved.sttFormattedFinals).toBe(true);
     expect(saved.autoSendDelayMs).toBe(3000);
+    expect(saved.usePromptOverrides).toBe(true);
   });
 
   test('POST /settings clears to default when blank', async () => {
@@ -72,5 +75,6 @@ describe('/settings page', () => {
     const saved = loadSettings();
     expect(saved.llmModel).toBe('gpt-4.1');
     expect(saved.maxTokens).toBe(1000);
+    expect(saved.usePromptOverrides).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- allow prompt files under `data/prompts` to override built‑in templates
- add `usePromptOverrides` setting and UI checkbox
- extend settings page with simple tab layout
- create utility to load prompt overrides with fallback
- update tests for new setting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846d7ed87088328a987b6df057df6ea