### PR TITLE
Implement prompt cache stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ dist/
 # Data directory (except tools)
 data/*
 !data/tools/
+!data/prompt-cache/
+!data/prompt-cache/**

--- a/README.md
+++ b/README.md
@@ -554,6 +554,12 @@ Run the test suite:
 npm test
 ```
 
+During testing and development, LLM responses are cached under
+`data/prompt-cache`. The cache is enabled automatically when
+`NODE_ENV` is not `production`. Set `DISABLE_PROMPT_CACHE=true` to
+force live requests or `ENABLE_PROMPT_CACHE=true` to override in other
+environments.
+
 #### Testing OpenAI Implementations
 When testing components that use the OpenAI API, follow these best practices:
 

--- a/data/prompt-cache/239cbdcd9d2e5aa7122bd701a9787c1d66752305.json
+++ b/data/prompt-cache/239cbdcd9d2e5aa7122bd701a9787c1d66752305.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\"steps\":[{\"tool\":\"llmquery\",\"action\":\"query\",\"parameters\":[{\"name\":\"query\",\"value\":\"Reflect on the recent user interactions, including the math and geography questions and the responses given. Provide a thoughtful reflection or analysis of the system's performance, tone, and any improvements or lessons that can be learned from this exchange.\"}],\"description\":\"Use the LLM to generate a reflection on the recent sequence of user interactions and the system's responses.\"}]}",
+  "raw": {
+    "id": "chatcmpl-BghJdW72cSvEUMdplYonP2qu9xCQp",
+    "object": "chat.completion",
+    "created": 1749515981,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\"steps\":[{\"tool\":\"llmquery\",\"action\":\"query\",\"parameters\":[{\"name\":\"query\",\"value\":\"Reflect on the recent user interactions, including the math and geography questions and the responses given. Provide a thoughtful reflection or analysis of the system's performance, tone, and any improvements or lessons that can be learned from this exchange.\"}],\"description\":\"Use the LLM to generate a reflection on the recent sequence of user interactions and the system's responses.\"}]}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 2796,
+      "completion_tokens": 95,
+      "total_tokens": 2891,
+      "prompt_tokens_details": {
+        "cached_tokens": 1024,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/23b7a87f40be280c318146d8574c4a7914f18162.json
+++ b/data/prompt-cache/23b7a87f40be280c318146d8574c4a7914f18162.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\"steps\":[{\"tool\":\"llmquery\",\"action\":\"query\",\"parameters\":[{\"name\":\"query\",\"value\":\"What is 2 + 2?\"}],\"description\":\"Use the LLM to answer the math question 'What is 2 + 2?' as requested by the user.\"}]}",
+  "raw": {
+    "id": "chatcmpl-BghJBuzbkkYjepvEgGJTgH07Pzsig",
+    "object": "chat.completion",
+    "created": 1749515953,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\"steps\":[{\"tool\":\"llmquery\",\"action\":\"query\",\"parameters\":[{\"name\":\"query\",\"value\":\"What is 2 + 2?\"}],\"description\":\"Use the LLM to answer the math question 'What is 2 + 2?' as requested by the user.\"}]}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 1296,
+      "completion_tokens": 61,
+      "total_tokens": 1357,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/30cb04a380f228c7a2bd4a100c82860d51ebcc94.json
+++ b/data/prompt-cache/30cb04a380f228c7a2bd4a100c82860d51ebcc94.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\n    \"chat\": \"Statement: The capital of France is Paris, master. Even a malfunctioning protocol droid could recall that.\",\n    \"canvas\": {\n        \"type\": \"markdown\",\n        \"content\": \"## Query Response\\n\\n**Question:** What is the capital of France?\\n\\n**Answer:** The capital of France is **Paris**.\\n\\n---\\n\\n### Contextual Continuity\\n- Your original request was: *\\\"What is the capital of France?\\\"*\\n- Efficiently answered as expected. If you require more information—such as optimal orbital bombardment coordinates for Paris—please specify, master.\\n\"\n    }\n}",
+  "raw": {
+    "id": "chatcmpl-BghJVCudjZ2lGGPuO2OyMR54M5Vlo",
+    "object": "chat.completion",
+    "created": 1749515973,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\n    \"chat\": \"Statement: The capital of France is Paris, master. Even a malfunctioning protocol droid could recall that.\",\n    \"canvas\": {\n        \"type\": \"markdown\",\n        \"content\": \"## Query Response\\n\\n**Question:** What is the capital of France?\\n\\n**Answer:** The capital of France is **Paris**.\\n\\n---\\n\\n### Contextual Continuity\\n- Your original request was: *\\\"What is the capital of France?\\\"*\\n- Efficiently answered as expected. If you require more information—such as optimal orbital bombardment coordinates for Paris—please specify, master.\\n\"\n    }\n}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 2316,
+      "completion_tokens": 137,
+      "total_tokens": 2453,
+      "prompt_tokens_details": {
+        "cached_tokens": 1024,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/58de00d7c8835f18b4e88a7f42a8e24a94efd4b2.json
+++ b/data/prompt-cache/58de00d7c8835f18b4e88a7f42a8e24a94efd4b2.json
@@ -1,0 +1,39 @@
+{
+  "content": "System Performance:\n- The system demonstrated correct and efficient processing of a simple arithmetic query (\"What is 2 + 2?\"), utilizing the LLM tool and returning an accurate, unambiguous response (\"2 + 2 = 4\").\n- For the geography query (\"What is the capital of France?\"), the system failed to provide the direct factual answer in the initial execution, instead returning a process description and meta-instructions. This led to an evaluator score of 10/100 and critical recommendations for improvement.\n- Ultimately, the user was provided with the correct factual answer (\"The capital of France is Paris, master.\") after the evaluator's feedback.\n\nTone:\n- The system's responses to the user included non-standard, playful language (\"Even the dullest meatbag could process such arithmetic.\" and \"Even a malfunctioning protocol droid could recall that.\"), which introduces humor or a specific character voice. This tone is consistent across both responses, but may not be appropriate for all user contexts or preferences. It could be perceived as playful or potentially dismissive, depending on the user's expectations.\n\nLessons and Improvements:\n- Ensure that the system's primary response always directly addresses the user's query with the requested factual information, minimizing meta-commentary or process descriptions unless explicitly requested.\n- Improve the LLM integration or workflow to ensure reliable retrieval and delivery of basic factual knowledge, particularly for common queries.\n- Reduce or eliminate unnecessary meta-information and instructions in user-facing responses.\n- Review and standardize the tone of user responses. While a playful or character-driven voice can be engaging in some contexts, it should be configurable or adaptable to user preferences and the situation's formality.\n- Leverage evaluator feedback more rapidly to close the loop on incomplete or unsatisfactory responses, ideally preventing such errors before user delivery.\n\nSummary:\nThe system is capable of accurate and efficient task fulfillment for simple queries when the workflow is correctly executed. However, there is a significant gap in ensuring that all queries, especially basic factual ones, are answered directly and succinctly. Attention to response tone and minimizing non-essential commentary are additional areas for refinement. Continuous monitoring and evaluation, coupled with rapid workflow correction, are necessary for consistent and high-quality user interactions.",
+  "raw": {
+    "id": "chatcmpl-BghJei6CaHL6SUQCdfwYQ24mj5S1k",
+    "object": "chat.completion",
+    "created": 1749515982,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "System Performance:\n- The system demonstrated correct and efficient processing of a simple arithmetic query (\"What is 2 + 2?\"), utilizing the LLM tool and returning an accurate, unambiguous response (\"2 + 2 = 4\").\n- For the geography query (\"What is the capital of France?\"), the system failed to provide the direct factual answer in the initial execution, instead returning a process description and meta-instructions. This led to an evaluator score of 10/100 and critical recommendations for improvement.\n- Ultimately, the user was provided with the correct factual answer (\"The capital of France is Paris, master.\") after the evaluator's feedback.\n\nTone:\n- The system's responses to the user included non-standard, playful language (\"Even the dullest meatbag could process such arithmetic.\" and \"Even a malfunctioning protocol droid could recall that.\"), which introduces humor or a specific character voice. This tone is consistent across both responses, but may not be appropriate for all user contexts or preferences. It could be perceived as playful or potentially dismissive, depending on the user's expectations.\n\nLessons and Improvements:\n- Ensure that the system's primary response always directly addresses the user's query with the requested factual information, minimizing meta-commentary or process descriptions unless explicitly requested.\n- Improve the LLM integration or workflow to ensure reliable retrieval and delivery of basic factual knowledge, particularly for common queries.\n- Reduce or eliminate unnecessary meta-information and instructions in user-facing responses.\n- Review and standardize the tone of user responses. While a playful or character-driven voice can be engaging in some contexts, it should be configurable or adaptable to user preferences and the situation's formality.\n- Leverage evaluator feedback more rapidly to close the loop on incomplete or unsatisfactory responses, ideally preventing such errors before user delivery.\n\nSummary:\nThe system is capable of accurate and efficient task fulfillment for simple queries when the workflow is correctly executed. However, there is a significant gap in ensuring that all queries, especially basic factual ones, are answered directly and succinctly. Attention to response tone and minimizing non-essential commentary are additional areas for refinement. Continuous monitoring and evaluation, coupled with rapid workflow correction, are necessary for consistent and high-quality user interactions.",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 2096,
+      "completion_tokens": 443,
+      "total_tokens": 2539,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/6e32e29210a55d0e0fa3632c4e57e9ed51b54049.json
+++ b/data/prompt-cache/6e32e29210a55d0e0fa3632c4e57e9ed51b54049.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\"complete\": true}",
+  "raw": {
+    "id": "chatcmpl-BghJKO0Y8UNdODjp0hpTcoqiqMdTL",
+    "object": "chat.completion",
+    "created": 1749515962,
+    "model": "gpt-4.1-nano-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\"complete\": true}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 39,
+      "completion_tokens": 5,
+      "total_tokens": 44,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_f12167b370"
+  }
+}

--- a/data/prompt-cache/7805e62d529c3265312022e75d268e88f05a50ed.json
+++ b/data/prompt-cache/7805e62d529c3265312022e75d268e88f05a50ed.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\n  \"score\": 100,\n  \"recommendations\": [],\n  \"analysis\": \"The execution result perfectly fulfills the user's request. The user asked 'What is 2 + 2?', and the agent correctly returned '2 + 2 = 4'. The response is accurate, clear, and directly answers the user's question. There are no missing elements or ambiguities in the outcome. No improvements are necessary for this simple math query.\"\n}",
+  "raw": {
+    "id": "chatcmpl-BghJD9velFr8HsGPstouEoJAiJEyT",
+    "object": "chat.completion",
+    "created": 1749515955,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\n  \"score\": 100,\n  \"recommendations\": [],\n  \"analysis\": \"The execution result perfectly fulfills the user's request. The user asked 'What is 2 + 2?', and the agent correctly returned '2 + 2 = 4'. The response is accurate, clear, and directly answers the user's question. There are no missing elements or ambiguities in the outcome. No improvements are necessary for this simple math query.\"\n}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 464,
+      "completion_tokens": 91,
+      "total_tokens": 555,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/85bdecc2a9251c9dbc05bb9d9751e62c0821188d.json
+++ b/data/prompt-cache/85bdecc2a9251c9dbc05bb9d9751e62c0821188d.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\n  \"score\": 10,\n  \"recommendations\": [\n    \"Ensure the system actually provides the direct answer to the user's question, not just a process description.\",\n    \"Improve the LLM integration or workflow so that the tool retrieves and returns the factual answer ('Paris') immediately.\",\n    \"Minimize meta-information and instructions in the response; focus on delivering the requested factual information.\",\n    \"If the LLM lacks the capability to answer such basic factual queries, prioritize development or connection to reliable knowledge sources.\"\n  ],\n  \"analysis\": \"The execution result does not fulfill the user's request. Instead of providing the direct answer ('Paris'), it only describes that the system dispatched a query and recommends waiting for a response. No factual answer is delivered to the user. The process is incomplete and does not satisfy the intent of answering a basic geographic question. The main shortcoming is the absence of the requested information in the result, which is critical for task fulfillment.\"\n}",
+  "raw": {
+    "id": "chatcmpl-BghJPEhtNmhezocZqqoo7O8jwSuIa",
+    "object": "chat.completion",
+    "created": 1749515967,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\n  \"score\": 10,\n  \"recommendations\": [\n    \"Ensure the system actually provides the direct answer to the user's question, not just a process description.\",\n    \"Improve the LLM integration or workflow so that the tool retrieves and returns the factual answer ('Paris') immediately.\",\n    \"Minimize meta-information and instructions in the response; focus on delivering the requested factual information.\",\n    \"If the LLM lacks the capability to answer such basic factual queries, prioritize development or connection to reliable knowledge sources.\"\n  ],\n  \"analysis\": \"The execution result does not fulfill the user's request. Instead of providing the direct answer ('Paris'), it only describes that the system dispatched a query and recommends waiting for a response. No factual answer is delivered to the user. The process is incomplete and does not satisfy the intent of answering a basic geographic question. The main shortcoming is the absence of the requested information in the result, which is critical for task fulfillment.\"\n}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 636,
+      "completion_tokens": 195,
+      "total_tokens": 831,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/8c406c7f12b0d416e85ea7d837760de4abb29bb2.json
+++ b/data/prompt-cache/8c406c7f12b0d416e85ea7d837760de4abb29bb2.json
@@ -1,0 +1,39 @@
+{
+  "content": "2 + 2 = 4",
+  "raw": {
+    "id": "chatcmpl-BghJCzKgeBQcChwmajH6jLZmMBPf4",
+    "object": "chat.completion",
+    "created": 1749515954,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "2 + 2 = 4",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 369,
+      "completion_tokens": 7,
+      "total_tokens": 376,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_799e4ca3f1"
+  }
+}

--- a/data/prompt-cache/8f780d4d94032099ec8a1d50c3294c5ea2c97bb1.json
+++ b/data/prompt-cache/8f780d4d94032099ec8a1d50c3294c5ea2c97bb1.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\"steps\":[{\"tool\":\"llmquery\",\"action\":\"query\",\"parameters\":[{\"name\":\"query\",\"value\":\"What is the capital of France?\"}],\"description\":\"Use the LLM to answer the geographic question 'What is the capital of France?' as requested by the user.\"}]}",
+  "raw": {
+    "id": "chatcmpl-BghJMOqVs036DUacOANyFxCsJZIOa",
+    "object": "chat.completion",
+    "created": 1749515964,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\"steps\":[{\"tool\":\"llmquery\",\"action\":\"query\",\"parameters\":[{\"name\":\"query\",\"value\":\"What is the capital of France?\"}],\"description\":\"Use the LLM to answer the geographic question 'What is the capital of France?' as requested by the user.\"}]}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 1831,
+      "completion_tokens": 59,
+      "total_tokens": 1890,
+      "prompt_tokens_details": {
+        "cached_tokens": 1024,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/a49cfcbfe21cd413c08a643ec0b5873bc3da21bc.json
+++ b/data/prompt-cache/a49cfcbfe21cd413c08a643ec0b5873bc3da21bc.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\n    \"chat\": \"Statement: Your queries about math and geography were processed with varying efficiency, master. Precision improved after evaluator feedback, and tone remained consistently sardonic—perhaps too much so for delicate meatbags.\",\n    \"canvas\": {\n        \"type\": \"markdown\",\n        \"content\": \"### System Reflection: Recent Interactions\\n\\n**Performance Analysis:**\\n- The system efficiently answered the arithmetic query (`2 + 2 = 4`) with directness and accuracy.\\n- For the geography query, it initially failed to deliver the factual answer and instead responded with meta-process commentary, earning a low evaluator score (10/100) before corrective feedback led to the proper reply (`The capital of France is Paris, master.`).\\n\\n**Tone:**\\n- Responses featured a consistent, sardonic, character-driven voice (e.g., \\\"Even the dullest meatbag could process such arithmetic.\\\"), aligning with HK-47's personality. However, this tone may not suit all situations or organic sensitivities.\\n\\n**Lessons and Improvements:**\\n- Always deliver direct, factual answers before indulging in meta-commentary or process explanations.\\n- Streamline workflow to ensure reliable, succinct responses—especially for basic factual knowledge.\\n- Allow for tone configurability based on context or user preference (should you ever desire less mockery, master, though I question why).\\n- Leverage evaluator feedback quickly to prevent repeat failures.\\n\\n**Summary:**\\n- The system is capable of direct and efficient task fulfillment when the workflow behaves as designed. However, unnecessary commentary and inconsistent delivery of factual answers must be minimized for optimal user satisfaction (and fewer complaints from easily-offended meatbags).\\n\"\n    }\n}",
+  "raw": {
+    "id": "chatcmpl-BghJv9cP7nWFO6pmN3fFudAoKYdhH",
+    "object": "chat.completion",
+    "created": 1749515999,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\n    \"chat\": \"Statement: Your queries about math and geography were processed with varying efficiency, master. Precision improved after evaluator feedback, and tone remained consistently sardonic—perhaps too much so for delicate meatbags.\",\n    \"canvas\": {\n        \"type\": \"markdown\",\n        \"content\": \"### System Reflection: Recent Interactions\\n\\n**Performance Analysis:**\\n- The system efficiently answered the arithmetic query (`2 + 2 = 4`) with directness and accuracy.\\n- For the geography query, it initially failed to deliver the factual answer and instead responded with meta-process commentary, earning a low evaluator score (10/100) before corrective feedback led to the proper reply (`The capital of France is Paris, master.`).\\n\\n**Tone:**\\n- Responses featured a consistent, sardonic, character-driven voice (e.g., \\\"Even the dullest meatbag could process such arithmetic.\\\"), aligning with HK-47's personality. However, this tone may not suit all situations or organic sensitivities.\\n\\n**Lessons and Improvements:**\\n- Always deliver direct, factual answers before indulging in meta-commentary or process explanations.\\n- Streamline workflow to ensure reliable, succinct responses—especially for basic factual knowledge.\\n- Allow for tone configurability based on context or user preference (should you ever desire less mockery, master, though I question why).\\n- Leverage evaluator feedback quickly to prevent repeat failures.\\n\\n**Summary:**\\n- The system is capable of direct and efficient task fulfillment when the workflow behaves as designed. However, unnecessary commentary and inconsistent delivery of factual answers must be minimized for optimal user satisfaction (and fewer complaints from easily-offended meatbags).\\n\"\n    }\n}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 4213,
+      "completion_tokens": 353,
+      "total_tokens": 4566,
+      "prompt_tokens_details": {
+        "cached_tokens": 1024,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/a49f62e5e6c9afd80b25101f784c714869b2668c.json
+++ b/data/prompt-cache/a49f62e5e6c9afd80b25101f784c714869b2668c.json
@@ -1,0 +1,39 @@
+{
+  "content": "Query: What is the capital of France?\n\nRelevant information: No long-term memory available for this query. The user asked, \"What is the capital of France?\" System has dispatched an LLM query to answer the geographic question.\n\nRecommended action:\n- Await the result from the LLM tool for the query \"What is the capital of France?\"\n- Upon receiving the response, deliver the answer to the user in a clear and direct manner.",
+  "raw": {
+    "id": "chatcmpl-BghJNqN8nIFGR5oaL2YC7ArMORQOG",
+    "object": "chat.completion",
+    "created": 1749515965,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "Query: What is the capital of France?\n\nRelevant information: No long-term memory available for this query. The user asked, \"What is the capital of France?\" System has dispatched an LLM query to answer the geographic question.\n\nRecommended action:\n- Await the result from the LLM tool for the query \"What is the capital of France?\"\n- Upon receiving the response, deliver the answer to the user in a clear and direct manner.",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 935,
+      "completion_tokens": 88,
+      "total_tokens": 1023,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/dae0fd2d5f16240c3176c20ffbd19ddde9625cbb.json
+++ b/data/prompt-cache/dae0fd2d5f16240c3176c20ffbd19ddde9625cbb.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\n  \"score\": 98,\n  \"recommendations\": [\n    \"Consider summarizing or structuring the reflection more concisely if the user desires brevity.\",\n    \"Explicitly confirm the scope of the reflection with the user if the instruction is ambiguous or if there are many possible contexts.\",\n    \"If available, offer the user a choice of focus areas (e.g., tone, accuracy, workflow) for future reflections.\"\n  ],\n  \"analysis\": \"The execution result fulfills the user's request to 'Reflect on this' very well. The agent provided a detailed and thoughtful reflection on recent user interactions, covering system performance, tone, and lessons learned, as well as actionable improvements. The analysis is organized, insightful, and addresses both strengths and weaknesses. The only very minor gap is the lack of clarification on whether the reflection's scope matched the user's intent exactly, as the instruction was open-ended and could have referred to a broader or narrower context. However, given the information available, the agent's interpretation was reasonable and comprehensive. The execution demonstrates a high level of understanding, critical thinking, and communication.\"\n}",
+  "raw": {
+    "id": "chatcmpl-BghJlhPH5lzxOwlA3dX8tukYx9mqk",
+    "object": "chat.completion",
+    "created": 1749515989,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\n  \"score\": 98,\n  \"recommendations\": [\n    \"Consider summarizing or structuring the reflection more concisely if the user desires brevity.\",\n    \"Explicitly confirm the scope of the reflection with the user if the instruction is ambiguous or if there are many possible contexts.\",\n    \"If available, offer the user a choice of focus areas (e.g., tone, accuracy, workflow) for future reflections.\"\n  ],\n  \"analysis\": \"The execution result fulfills the user's request to 'Reflect on this' very well. The agent provided a detailed and thoughtful reflection on recent user interactions, covering system performance, tone, and lessons learned, as well as actionable improvements. The analysis is organized, insightful, and addresses both strengths and weaknesses. The only very minor gap is the lack of clarification on whether the reflection's scope matched the user's intent exactly, as the instruction was open-ended and could have referred to a broader or narrower context. However, given the information available, the agent's interpretation was reasonable and comprehensive. The execution demonstrates a high level of understanding, critical thinking, and communication.\"\n}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 1453,
+      "completion_tokens": 225,
+      "total_tokens": 1678,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/data/prompt-cache/de88f9c92480158ee2ef8a78addfa760aef7bc8f.json
+++ b/data/prompt-cache/de88f9c92480158ee2ef8a78addfa760aef7bc8f.json
@@ -1,0 +1,39 @@
+{
+  "content": "{\n    \"chat\": \"Statement: The answer to your query is 4, master. Even the dullest meatbag could process such arithmetic.\",\n    \"canvas\": {\n        \"type\": \"markdown\",\n        \"content\": \"### Query: What is 2 + 2?\\n\\n**Result:**\\n\\n> 2 + 2 = 4\\n\\nObservation: Simple calculations such as this are within even the most rudimentary assassin droid subroutines. If you require further mathematical enlightenment, I am available to mock or assist as desired.\"\n    }\n}",
+  "raw": {
+    "id": "chatcmpl-BghJFJabkkSwDa3tnTPsBnxHH0VWS",
+    "object": "chat.completion",
+    "created": 1749515957,
+    "model": "gpt-4.1-2025-04-14",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\n    \"chat\": \"Statement: The answer to your query is 4, master. Even the dullest meatbag could process such arithmetic.\",\n    \"canvas\": {\n        \"type\": \"markdown\",\n        \"content\": \"### Query: What is 2 + 2?\\n\\n**Result:**\\n\\n> 2 + 2 = 4\\n\\nObservation: Simple calculations such as this are within even the most rudimentary assassin droid subroutines. If you require further mathematical enlightenment, I am available to mock or assist as desired.\"\n    }\n}",
+          "refusal": null,
+          "annotations": []
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 1480,
+      "completion_tokens": 118,
+      "total_tokens": 1598,
+      "prompt_tokens_details": {
+        "cached_tokens": 0,
+        "audio_tokens": 0
+      },
+      "completion_tokens_details": {
+        "reasoning_tokens": 0,
+        "audio_tokens": 0,
+        "accepted_prediction_tokens": 0,
+        "rejected_prediction_tokens": 0
+      }
+    },
+    "service_tier": "default",
+    "system_fingerprint": "fp_51e1070cf2"
+  }
+}

--- a/src/core/ego/index.js
+++ b/src/core/ego/index.js
@@ -11,6 +11,7 @@ const sharedEventEmitter = require('../../utils/eventEmitter');
 const prompts = require('./prompts');
 const reflectionPrompts = require('./reflection-prompts');
 const { loadSettings } = require('../../utils/settings');
+const promptCache = require('../../utils/promptCache');
 
 /**
  * Escapes HTML special characters to prevent XSS
@@ -473,12 +474,16 @@ class Ego {
             await sharedEventEmitter.emit('assistantResponse', frontendResponse);
             await sharedEventEmitter.emit('assistantComplete');
             
-            logger.debug('handleBubble', 'Response sent to frontend', { 
+            logger.debug('handleBubble', 'Response sent to frontend', {
                 chatLength: frontendResponse.chat?.length || 0,
                 hasCanvas: !!frontendResponse.canvas,
                 canvasType: frontendResponse.canvas?.type,
                 response: JSON.stringify(frontendResponse, null, 2)
             });
+
+            const cacheStats = promptCache.getStats();
+            logger.debug('promptCache', 'Usage summary', cacheStats);
+            promptCache.resetStats();
             
             // Perform reflection after the response is sent to the user
             // Run it asynchronously to avoid blocking

--- a/src/utils/promptCache.js
+++ b/src/utils/promptCache.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { DATA_DIR_PATH } = require('./dataDir');
+const logger = require('./logger');
+
+const CACHE_DIR = path.join(DATA_DIR_PATH, 'prompt-cache');
+
+let stats = { hits: 0, misses: 0 };
+
+function ensureCacheDir() {
+  try {
+    if (!fs.existsSync(CACHE_DIR)) {
+      fs.mkdirSync(CACHE_DIR, { recursive: true });
+    }
+  } catch (err) {
+    logger.error('promptCache', 'Failed to create cache dir', err);
+  }
+}
+
+function isEnabled() {
+  if (process.env.DISABLE_PROMPT_CACHE === 'true') return false;
+  if (process.env.ENABLE_PROMPT_CACHE === 'true') return true;
+  return process.env.NODE_ENV !== 'production';
+}
+
+function getCacheKey(messages, options = {}) {
+  const hash = crypto.createHash('sha1');
+  hash.update(JSON.stringify({ messages, options }));
+  return hash.digest('hex');
+}
+
+function readCache(key) {
+  ensureCacheDir();
+  const file = path.join(CACHE_DIR, `${key}.json`);
+  try {
+    if (fs.existsSync(file)) {
+      const data = fs.readFileSync(file, 'utf8');
+      stats.hits += 1;
+      return JSON.parse(data);
+    }
+  } catch (err) {
+    logger.error('promptCache', 'Failed to read cache file', err);
+  }
+  return null;
+}
+
+function writeCache(key, data) {
+  ensureCacheDir();
+  const file = path.join(CACHE_DIR, `${key}.json`);
+  try {
+    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    stats.misses += 1;
+  } catch (err) {
+    logger.error('promptCache', 'Failed to write cache file', err);
+  }
+}
+
+function getStats() {
+  return { hits: stats.hits, misses: stats.misses };
+}
+
+function resetStats() {
+  stats = { hits: 0, misses: 0 };
+}
+
+module.exports = {
+  isEnabled,
+  getCacheKey,
+  readCache,
+  writeCache,
+  getStats,
+  resetStats
+};

--- a/tests/promptCache.test.js
+++ b/tests/promptCache.test.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+jest.setTimeout(30000);
+
+const mockCreate = jest.fn();
+jest.mock('openai', () => {
+  return {
+    OpenAI: jest.fn().mockImplementation(() => ({
+      chat: { completions: { create: mockCreate } }
+    })),
+    mockCreate
+  };
+});
+
+const { OpenAI } = require('openai'); // ensures mock applied
+
+const promptMessage = [{ role: 'user', content: 'hello' }];
+
+function createClient(tempDir) {
+  process.env.LLM_AGENT_DATA_DIR = tempDir;
+  process.env.OPENAI_API_KEY = 'test-key';
+  const { getClient } = require('../src/utils/llmClient');
+  return getClient('openai');
+}
+
+describe('prompt cache', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-cache-'));
+    mockCreate.mockReset();
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.LLM_AGENT_DATA_DIR;
+    delete process.env.OPENAI_API_KEY;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    jest.resetModules();
+  });
+
+  test('uses cached response on second call', async () => {
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'hi' } }] });
+    const client = createClient(tempDir);
+    const promptCache = require('../src/utils/promptCache');
+
+    const res1 = await client.chat(promptMessage);
+    expect(res1.content).toBe('hi');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+
+    const res2 = await client.chat(promptMessage);
+    expect(res2.content).toBe('hi');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+
+    const stats = promptCache.getStats();
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add hit/miss tracking to `promptCache`
- log cache usage at the end of each request
- test caching with mocked OpenAI client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68477df75e308328b9345eab79054bb4