### PR TITLE
Add external default settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ An AI agent that chats and executes tasks using OpenAI models and a flexible too
    docker-compose up --build
    ```
 
-The first run generates `data/settings.json` which can be edited to adjust defaults.
+Default configuration is loaded from `config/defaultSettings.json`. The first run
+generates `data/settings.json` which stores any runtime/user overrides.
 
 ## Configuration
 
-Set `LLM_AGENT_DATA_DIR` to choose where the `data` directory lives. See `data/settings.json` for other runtime options after the first start.
+Set `LLM_AGENT_DATA_DIR` to choose where the `data` directory lives. See
+`data/settings.json` for runtime options saved after the first start.
 
 ## Development
 

--- a/config/defaultSettings.json
+++ b/config/defaultSettings.json
@@ -1,0 +1,16 @@
+{
+  "llmModel": "gpt-4.1",
+  "plannerModel": "",
+  "evaluatorModel": "",
+  "queryModel": "",
+  "bubbleModel": "",
+  "reflectionModel": "",
+  "utteranceCheckModel": "gpt-4.1-nano",
+  "maxTokens": 1000,
+  "ttsVoiceId": "D38z5RcWu1voky8WS1ja",
+  "ttsModelId": "eleven_flash_v2_5",
+  "sttSampleRate": 16000,
+  "sttFormattedFinals": true,
+  "autoSendDelayMs": 2000,
+  "usePromptOverrides": true
+}

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -3,8 +3,9 @@ const path = require('path');
 const { DATA_DIR_PATH } = require('./dataDir');
 
 const SETTINGS_PATH = path.join(DATA_DIR_PATH, 'settings.json');
+const DEFAULTS_PATH = path.resolve(__dirname, '../../config/defaultSettings.json');
 
-const defaultSettings = {
+const fallbackDefaults = {
   // Base OpenAI model used if a specific one is not provided
   llmModel: 'gpt-4.1',
   // Optional specialised models for different subsystems
@@ -27,6 +28,16 @@ const defaultSettings = {
   // Whether to load prompt overrides from the data directory
   usePromptOverrides: true
 };
+
+let fileDefaults = {};
+try {
+  const data = fs.readFileSync(DEFAULTS_PATH, 'utf8');
+  fileDefaults = JSON.parse(data);
+} catch (err) {
+  // If the file is missing or invalid, fall back to built-in defaults
+}
+
+const defaultSettings = { ...fallbackDefaults, ...fileDefaults };
 
 function loadRawSettings() {
   try {


### PR DESCRIPTION
## Summary
- provide `config/defaultSettings.json` to store default settings
- load defaults from new JSON while falling back to builtin options
- update README with guidance on configuration files

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847e3c5c47083289873d62a6a2adeca