### PR TITLE
Add scheduler viewTasks action

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ console.log(`Deleted ${deleted} old cache files, ${errors} errors`);
 - Logs stored under `data/logs`
 - Run tests with `npm test`
 - Cache debug logs are available in the main application logs with the `promptCache` prefix
+- A scheduler tool allows tasks to be queued for periodic execution, viewed, or removed. Tasks are stored under `data/scheduler/tasks.json` and run as regular user messages.
 
 ## Documentation
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -7,11 +7,13 @@ const { planner } = require('./planner');
 const Ego = require('./ego');
 const { coordinator } = require('./coordinator');
 const { evaluator } = require('./evaluator');
+const scheduler = require('./scheduler');
 
 module.exports = {
   memory,
   planner,
   Ego,
   coordinator,
-  evaluator
+  evaluator,
+  scheduler
 };

--- a/src/core/scheduler/index.js
+++ b/src/core/scheduler/index.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+const { DATA_DIR_PATH } = require('../../utils/dataDir');
+const logger = require('../../utils/logger');
+
+const schedulerDir = path.join(DATA_DIR_PATH, 'scheduler');
+const tasksFile = path.join(schedulerDir, 'tasks.json');
+
+class Scheduler {
+    constructor() {
+        this.tasks = new Map(); // id => { config, timer }
+        this.sessionManager = null;
+    }
+
+    async initialize(sessionManager) {
+        this.sessionManager = sessionManager;
+        if (!fs.existsSync(schedulerDir)) {
+            fs.mkdirSync(schedulerDir, { recursive: true });
+        }
+        if (!fs.existsSync(tasksFile)) {
+            fs.writeFileSync(tasksFile, '[]', 'utf-8');
+        }
+        this.loadTasksFromFile();
+    }
+
+    loadTasksFromFile() {
+        try {
+            const data = fs.readFileSync(tasksFile, 'utf-8');
+            const tasks = JSON.parse(data);
+            tasks.forEach(t => this.scheduleTask(t));
+        } catch (err) {
+            logger.error('scheduler', 'Failed to load tasks', { error: err.message });
+        }
+    }
+
+    saveTasksToFile() {
+        try {
+            const tasks = Array.from(this.tasks.values()).map(t => t.config);
+            fs.writeFileSync(tasksFile, JSON.stringify(tasks, null, 2), 'utf-8');
+        } catch (err) {
+            logger.error('scheduler', 'Failed to save tasks', { error: err.message });
+        }
+    }
+
+    scheduleTask(config) {
+        if (!config.id) config.id = uuidv4();
+        const timer = setInterval(() => this.runTask(config.id), config.frequencySec * 1000);
+        this.tasks.set(config.id, { config, timer });
+    }
+
+    runTask(id) {
+        const taskEntry = this.tasks.get(id);
+        if (!taskEntry) return;
+        const { config } = taskEntry;
+        config.lastRun = Date.now();
+        this.saveTasksToFile();
+        if (!this.sessionManager) {
+            logger.error('scheduler', 'No session manager available for task');
+            return;
+        }
+        this.sessionManager.handleMessage(config.message).catch(err => {
+            logger.error('scheduler', 'Task execution failed', { error: err.message });
+        });
+    }
+
+    registerTask(message, frequencySec) {
+        const config = { id: uuidv4(), message, frequencySec, lastRun: 0 };
+        this.scheduleTask(config);
+        this.saveTasksToFile();
+        return config;
+    }
+
+    removeTask(id) {
+        const entry = this.tasks.get(id);
+        if (!entry) return false;
+        clearInterval(entry.timer);
+        this.tasks.delete(id);
+        this.saveTasksToFile();
+        return true;
+    }
+
+    listTasks() {
+        return Array.from(this.tasks.values()).map(t => t.config);
+    }
+}
+
+module.exports = new Scheduler();

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const SessionManager = require("./session/SessionManager");
 const ChatLogWriter = require("./session/ChatLogWriter");
 const { loadSettings, saveSettings, loadRawSettings, defaultSettings } = require('./utils/settings');
 const toolManager = require('./mcp');
+const scheduler = core.scheduler;
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -231,6 +232,7 @@ async function startServer() {
         retainExchanges: settings.session?.retain_exchanges,
         chatLogWriter
     });
+    await scheduler.initialize(sessionManager);
 
     if (initialMessage) {
         await sessionManager.handleMessage(initialMessage);

--- a/src/tools/scheduler.js
+++ b/src/tools/scheduler.js
@@ -1,0 +1,93 @@
+const logger = require('../utils/logger');
+const scheduler = require('../core/scheduler');
+
+class SchedulerTool {
+    constructor() {
+        this.name = 'scheduler';
+        this.description = 'Tool for managing scheduled tasks';
+    }
+
+    getCapabilities() {
+        return {
+            name: this.name,
+            description: this.description,
+            actions: [
+                {
+                    name: 'addTask',
+                    description: 'Add a scheduled task',
+                    parameters: [
+                        { name: 'message', description: 'Message to process', type: 'string', required: true },
+                        { name: 'frequencySec', description: 'How often to run in seconds', type: 'number', required: true }
+                    ]
+                },
+                {
+                    name: 'removeTask',
+                    description: 'Remove a task by id',
+                    parameters: [ { name: 'id', description: 'Task id', type: 'string', required: true } ]
+                },
+                {
+                    name: 'listTasks',
+                    description: 'List scheduled tasks',
+                    parameters: []
+                },
+                {
+                    name: 'viewTasks',
+                    description: 'Alias for listTasks',
+                    parameters: []
+                }
+            ]
+        };
+    }
+
+    async addTask(params) {
+        const msgParam = params.find(p => p.name === 'message');
+        const freqParam = params.find(p => p.name === 'frequencySec');
+        if (!msgParam || !freqParam) {
+            throw new Error('message and frequencySec are required');
+        }
+        const task = scheduler.registerTask(msgParam.value, Number(freqParam.value));
+        return { status: 'success', task };
+    }
+
+    async removeTask(params) {
+        const idParam = params.find(p => p.name === 'id');
+        if (!idParam) throw new Error('id is required');
+        const success = scheduler.removeTask(idParam.value);
+        return success ? { status: 'success' } : { status: 'error', error: 'Task not found' };
+    }
+
+    async listTasks() {
+        const tasks = scheduler.listTasks();
+        return { status: 'success', tasks };
+    }
+
+    async viewTasks() {
+        return this.listTasks();
+    }
+
+    async execute(action, parameters) {
+        try {
+            let parsed = parameters;
+            if (typeof parameters === 'string') {
+                parsed = JSON.parse(parameters);
+            }
+            switch(action) {
+                case 'addTask':
+                    return await this.addTask(parsed);
+                case 'removeTask':
+                    return await this.removeTask(parsed);
+                case 'listTasks':
+                    return await this.listTasks();
+                case 'viewTasks':
+                    return await this.viewTasks();
+                default:
+                    return { status: 'error', error: `Unknown action: ${action}` };
+            }
+        } catch (err) {
+            logger.error('SchedulerTool', 'Execution failed', { error: err.message });
+            return { status: 'error', error: err.message };
+        }
+    }
+}
+
+module.exports = new SchedulerTool();


### PR DESCRIPTION
## Summary
- add `viewTasks` action to scheduler tool
- update scheduler docs in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d59a550048328a14b0d1a0918705b