### PR TITLE
Align manual session cleanup with idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An AI agent that chats and executes tasks using OpenAI models and a flexible too
 - WebSocket API for real-time interaction
 - Multiline chat input for longer messages
 - Text-to-Speech (TTS) for assistant responses (with smart playback)
+- Sleep mode for manual session cleanup (consolidates memory and trims history)
 
 ## Getting Started
 

--- a/public/index.html
+++ b/public/index.html
@@ -58,9 +58,9 @@
         </div>
         <header class="main-header">
             <div class="system-controls">
-                <button id="reset-button" class="reset-button" title="Reset Session">
-                    <span class="reset-icon">🔄</span>
-                    <span class="reset-text">Reset Session</span>
+                <button id="sleep-button" class="sleep-button" title="Sleep (Session Cleanup)">
+                    <span class="sleep-icon">💤</span>
+                    <span class="sleep-text">Sleep</span>
                 </button>
                 <button onclick="toggleDebug()" class="debug-toggle">Debug ▼</button>
                 <button onclick="toggleSubsystem('planner')" class="subsystem-toggle planner-toggle">

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -585,27 +585,27 @@ function handleInterrupt() {
 }
 
 /**
- * Handle reset button click
- * Prompts the user for confirmation before sending reset request
+ * Handle sleep button click
+ * Prompts the user for confirmation before sending sleep request
  */
-function handleReset() {
+function handleSleep() {
     // Show confirmation dialog
-    const clearHistory = confirm('Do you want to clear the chat history? Click OK to clear history or Cancel to keep history but reset the session.');
-    
-    console.log('Reset requested, clear history:', clearHistory);
-    
-    // Send reset request to server
+    const clearHistory = confirm('Do you want to clear the chat history? Click OK to clear history or Cancel to keep recent context.');
+
+    console.log('Sleep requested, clear history:', clearHistory);
+
+    // Send sleep request to server
     if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ 
-            type: 'reset',
+        ws.send(JSON.stringify({
+            type: 'sleep',
             clearHistory: clearHistory,
             reason: 'user-requested'
         }));
-        
-        setStatus('Resetting session...');
+
+        setStatus('Entering sleep mode...');
     } else {
-        console.warn('WebSocket not connected, cannot send reset request');
-        addMessage('system', 'Cannot reset session: WebSocket not connected');
+        console.warn('WebSocket not connected, cannot send sleep request');
+        addMessage('system', 'Cannot enter sleep mode: WebSocket not connected');
     }
 }
 
@@ -912,17 +912,17 @@ function connect() {
                 addMessage('system', `Operation cancelled: ${data.reason || 'user-requested'}`);
                 break;
                 
-            case 'resetResult':
-                console.log('Reset result received:', data);
-                
-                // Add a message about the reset
-                addMessage('system', data.success ? 
-                    'Session reset successfully.' : 
-                    `Failed to reset session: ${data.message || 'Unknown error'}`);
+            case 'sleepResult':
+                console.log('Sleep result received:', data);
+
+                // Add a message about the sleep cleanup
+                addMessage('system', data.success ?
+                    'Session cleaned up successfully.' :
+                    `Failed to enter sleep mode: ${data.message || 'Unknown error'}`);
                 break;
-                
-            case 'reset':
-                console.log('Session reset by server:', data);
+
+            case 'sleep':
+                console.log('Session cleanup by server:', data);
                 
                 // Clear the busy state if we were processing
                 if (isProcessing) {
@@ -938,8 +938,8 @@ function connect() {
                         messagesContainer.innerHTML = '';
                     }
                     
-                    // Add a system message about the reset
-                    addMessage('system', `Session has been reset (${data.reason || 'unknown reason'})`);
+                    // Add a system message about the cleanup
+                    addMessage('system', `Session cleaned up (${data.reason || 'unknown reason'})`);
                 }
                 break;
                 
@@ -1181,10 +1181,10 @@ function connect() {
                 showStatus('Assistant is busy with another request', { noSpinner: true });
                 break;
 
-            case 'reset':
+            case 'sleep':
                 const messagesDiv = document.getElementById('messages');
                 if (messagesDiv) messagesDiv.innerHTML = '';
-                showStatus('Conversation context reset due to inactivity', { persistent: true, noSpinner: true });
+                showStatus('Conversation context trimmed due to inactivity', { persistent: true, noSpinner: true });
                 break;
 
             case 'connected':
@@ -2599,12 +2599,12 @@ document.addEventListener('DOMContentLoaded', () => {
         console.warn('Interrupt button not found in the DOM.');
     }
     
-    // Initialize reset button
-    const resetButton = document.getElementById('reset-button');
-    if (resetButton) {
-        resetButton.addEventListener('click', handleReset);
+    // Initialize sleep button
+    const sleepButton = document.getElementById('sleep-button');
+    if (sleepButton) {
+        sleepButton.addEventListener('click', handleSleep);
     } else {
-        console.warn('Reset button not found. Reset functionality will not be available.');
+        console.warn('Sleep button not found. Sleep functionality will not be available.');
     }
 
     connect(); // Establishes WebSocket and might enable/disable inputs in ws.onopen

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -548,8 +548,8 @@ header {
     animation: pulse 2s infinite;
 }
 
-/* Reset button styling */
-#reset-button {
+/* Sleep button styling */
+#sleep-button {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -565,25 +565,25 @@ header {
     min-width: 70px;
 }
 
-#reset-button:hover {
+#sleep-button:hover {
     background-color: #e0e0e0;
     transform: translateY(-1px);
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
-#reset-button:active {
+#sleep-button:active {
     transform: translateY(1px);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
-#reset-button .reset-icon {
+#sleep-button .sleep-icon {
     margin-right: 6px;
     font-size: 16px;
     display: inline-flex;
     align-items: center;
 }
 
-#reset-button .reset-text {
+#sleep-button .sleep-text {
     font-weight: 600;
     letter-spacing: 0.3px;
 }

--- a/session_management_plan.md
+++ b/session_management_plan.md
@@ -30,7 +30,7 @@ This plan outlines the implementation and improvements to the session management
 - WebSocket client handling is complete.
 - Local echo for user messages added and duplicate broadcast echoes suppressed.
 - Server-side tracking of system status messages implemented.
-- Reset button moved to system-controls div and relabelled to "Reset Session".
+- Sleep button added to system-controls div (replacing the old Reset Session button).
 
 ## Completed Tasks
 - [x] Review and document new session management architecture
@@ -58,7 +58,7 @@ This plan outlines the implementation and improvements to the session management
   - [x] Broadcast initial system status to new clients
   - [x] Update client to receive and display server-tracked system status messages
   - [x] Fix lint errors in SessionManager
-- [x] Rename reset button label/ID to "Reset Session"
+  - [x] Replace Reset Session button with Sleep button
 
 ## Pending Tasks
 - [ ] Implement multi-channel input (email, CLI/console)

--- a/src/index.js
+++ b/src/index.js
@@ -258,19 +258,19 @@ async function startServer() {
                     return;
                 }
                 
-                // Handle session reset request
-                if (data.type === 'reset') {
+                // Handle session sleep/cleanup request (legacy: reset)
+                if (data.type === 'sleep' || data.type === 'reset') {
                     const options = {
                         clearHistory: data.clearHistory === true,
                         consolidateMemory: data.consolidateMemory !== false,
                         reason: data.reason || 'user-requested'
                     };
-                    
-                    const result = await sessionManager.resetSession(options);
+
+                    const result = await sessionManager.sleep(options);
                     ws.send(JSON.stringify({
-                        type: 'resetResult',
+                        type: 'sleepResult',
                         success: !result.error,
-                        message: result.message || (result.error ? 'Failed to reset session' : 'Session reset successful')
+                        message: result.message || (result.error ? 'Failed to enter sleep mode' : 'Sleep successful')
                     }));
                     return;
                 }


### PR DESCRIPTION
## Summary
- unify idle timeout cleanup and manual cleanup logic
- rename `Reset Session` to **Sleep** in UI and docs
- replace `resetSession` with new `sleep` method
- handle new `sleep` message type on server and client
- document Sleep feature

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d50ebdd4c8328b174f1c1bbeacaee