### PR TITLE
Add scroll-to-input button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -56,6 +56,7 @@
                 </div>
             </div>
         </div>
+        <button id="scroll-to-input" class="scroll-to-input" aria-label="Jump to chat input">⬇️</button>
         <header class="main-header">
             <div class="system-controls">
                 <button id="reset-button" class="reset-button" title="Reset Session">

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -36,6 +36,7 @@ let autoSendToggle = null;
 let voiceStatusIndicator = null;
 let chatInputField = null; // Will be assigned in DOMContentLoaded
 let sendButton = null; // Will be assigned in DOMContentLoaded
+let scrollToInputBtn = null; // Floating button for small screens
 
 // ElevenLabs TTS Variables
 let elevenLabsAudioContext = null;
@@ -783,7 +784,8 @@ function addMessage(type, content, format = 'basic', messageId = null, options =
     
     messagesDiv.appendChild(messageDiv);
     messagesDiv.scrollTop = messagesDiv.scrollHeight;
-    
+    updateScrollButton();
+
     // If there's canvas content, update the canvas
     if (canvasContent) {
         updateCanvas(canvasContent);
@@ -813,9 +815,34 @@ async function fetchHistory() {
         
         // Reset the flag after loading history
         isLoadingHistory = false;
+        updateScrollButton();
     } catch (err) {
         console.error('Failed to fetch history', err);
         isLoadingHistory = false; // Reset flag on error too
+    }
+}
+
+// Show or hide the floating scroll button based on message scroll position
+function updateScrollButton() {
+    if (!scrollToInputBtn || !chatInputField) return;
+    const rect = chatInputField.getBoundingClientRect();
+    const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+    if (fullyVisible) {
+        scrollToInputBtn.classList.remove('visible');
+    } else {
+        scrollToInputBtn.classList.add('visible');
+    }
+}
+
+function scrollToInput() {
+    const messagesDiv = document.getElementById('messages');
+    if (messagesDiv) {
+        messagesDiv.scrollTo({ top: messagesDiv.scrollHeight, behavior: 'smooth' });
+    }
+    if (chatInputField) {
+        const top = chatInputField.getBoundingClientRect().top + window.pageYOffset - 20;
+        window.scrollTo({ top, behavior: 'smooth' });
+        chatInputField.focus();
     }
 }
 
@@ -843,10 +870,12 @@ function connect() {
 
         if (sendButton) {
             sendButton.disabled = false;
+            sendButton.innerHTML = 'Send';
         } else {
             console.error('Send button not found in ws.onopen');
         }
 
+        clearStatus();
         showStatus('Connected to server', { noSpinner: true });
     };
     
@@ -2523,6 +2552,7 @@ document.addEventListener('DOMContentLoaded', () => {
     chatInputField = document.getElementById('chatInput');
     sendButton = document.getElementById('send-button'); // Assign sendButton globally
     voiceInputToggleBtn = document.getElementById('voiceInputToggle');
+    scrollToInputBtn = document.getElementById('scroll-to-input');
     
     // Debug log to verify chatInputField is found
     console.log('[DEBUG] chatInputField found:', chatInputField !== null);
@@ -2665,6 +2695,16 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Initialize message counts
     updateMessageCounts();
+
+    // Setup scroll-to-input button functionality
+    const messagesDiv = document.getElementById('messages');
+    if (scrollToInputBtn) {
+        scrollToInputBtn.addEventListener('click', scrollToInput);
+        window.addEventListener('scroll', updateScrollButton, { passive: true });
+        window.addEventListener('resize', updateScrollButton);
+        if (messagesDiv) messagesDiv.addEventListener('scroll', updateScrollButton);
+        updateScrollButton();
+    }
 
     if (chatInputField) {
         chatInputField.addEventListener('keypress', function(event) {

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1375,3 +1375,27 @@ header {
         max-height: calc(95vh - 60px);
     }
 }
+
+/* Floating button to jump back to the chat input */
+#scroll-to-input {
+    position: fixed;
+    bottom: 80px;
+    right: 20px;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: #0084ff;
+    color: #fff;
+    border: none;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+    z-index: 1000;
+}
+
+#scroll-to-input.visible {
+    display: flex;
+}


### PR DESCRIPTION
## Summary
- add floating "scroll-to-input" button in the chat UI
- show or hide the button based on scroll position
- wire button to scroll smoothly to the message input
- reset Send button label on reconnect

## Testing
- `npm install`
- `CI=true npm test` *(fails: open handles cause hang, but all suites show PASS)*

------
https://chatgpt.com/codex/tasks/task_e_684d732ccad48328a73bea24c3f5886b