### PR TITLE
Implement event-based scheduler and sleep tool

### DIFF
--- a/src/core/scheduler/index.js
+++ b/src/core/scheduler/index.js
@@ -3,13 +3,16 @@ const path = require('path');
 const { v4: uuidv4 } = require('uuid');
 const { DATA_DIR_PATH } = require('../../utils/dataDir');
 const logger = require('../../utils/logger');
+const sharedEventEmitter = require('../../utils/eventEmitter');
+const toolManager = require('../../mcp');
 
 const schedulerDir = path.join(DATA_DIR_PATH, 'scheduler');
 const tasksFile = path.join(schedulerDir, 'tasks.json');
 
 class Scheduler {
     constructor() {
-        this.tasks = new Map(); // id => { config, timer }
+        // id => { config, timer?, listener? }
+        this.tasks = new Map();
         this.sessionManager = null;
     }
 
@@ -22,13 +25,21 @@ class Scheduler {
             fs.writeFileSync(tasksFile, '[]', 'utf-8');
         }
         this.loadTasksFromFile();
+        // Emit startup event for any tasks listening for it
+        sharedEventEmitter.emit('startup');
     }
 
     loadTasksFromFile() {
         try {
             const data = fs.readFileSync(tasksFile, 'utf-8');
             const tasks = JSON.parse(data);
-            tasks.forEach(t => this.scheduleTask(t));
+            tasks.forEach(t => {
+                if (t.eventName) {
+                    this.scheduleEventTask(t);
+                } else {
+                    this.scheduleIntervalTask(t);
+                }
+            });
         } catch (err) {
             logger.error('scheduler', 'Failed to load tasks', { error: err.message });
         }
@@ -43,10 +54,17 @@ class Scheduler {
         }
     }
 
-    scheduleTask(config) {
+    scheduleIntervalTask(config) {
         if (!config.id) config.id = uuidv4();
         const timer = setInterval(() => this.runTask(config.id), config.frequencySec * 1000);
         this.tasks.set(config.id, { config, timer });
+    }
+
+    scheduleEventTask(config) {
+        if (!config.id) config.id = uuidv4();
+        const listener = () => this.runTask(config.id);
+        sharedEventEmitter.on(config.eventName, listener);
+        this.tasks.set(config.id, { config, listener });
     }
 
     runTask(id) {
@@ -55,18 +73,50 @@ class Scheduler {
         const { config } = taskEntry;
         config.lastRun = Date.now();
         this.saveTasksToFile();
-        if (!this.sessionManager) {
-            logger.error('scheduler', 'No session manager available for task');
-            return;
+        if (config.toolName) {
+            const tool = toolManager.getTool(config.toolName);
+            if (tool) {
+                tool.execute(config.action || 'sleep', config.parameters || []).catch(err => {
+                    logger.error('scheduler', 'Tool task failed', { error: err.message });
+                });
+            } else {
+                logger.error('scheduler', `Tool not found: ${config.toolName}`);
+            }
+        } else if (config.message) {
+            if (!this.sessionManager) {
+                logger.error('scheduler', 'No session manager available for task');
+                return;
+            }
+            this.sessionManager.handleMessage(config.message).catch(err => {
+                logger.error('scheduler', 'Task execution failed', { error: err.message });
+            });
         }
-        this.sessionManager.handleMessage(config.message).catch(err => {
-            logger.error('scheduler', 'Task execution failed', { error: err.message });
-        });
     }
 
     registerTask(message, frequencySec) {
         const config = { id: uuidv4(), message, frequencySec, lastRun: 0 };
-        this.scheduleTask(config);
+        this.scheduleIntervalTask(config);
+        this.saveTasksToFile();
+        return config;
+    }
+
+    registerToolTask(toolName, action, parameters, frequencySec) {
+        const config = { id: uuidv4(), toolName, action, parameters, frequencySec, lastRun: 0 };
+        this.scheduleIntervalTask(config);
+        this.saveTasksToFile();
+        return config;
+    }
+
+    registerEventTask(eventName, message) {
+        const config = { id: uuidv4(), eventName, message };
+        this.scheduleEventTask(config);
+        this.saveTasksToFile();
+        return config;
+    }
+
+    registerEventToolTask(eventName, toolName, action, parameters) {
+        const config = { id: uuidv4(), eventName, toolName, action, parameters };
+        this.scheduleEventTask(config);
         this.saveTasksToFile();
         return config;
     }
@@ -74,7 +124,10 @@ class Scheduler {
     removeTask(id) {
         const entry = this.tasks.get(id);
         if (!entry) return false;
-        clearInterval(entry.timer);
+        if (entry.timer) clearInterval(entry.timer);
+        if (entry.listener && entry.config.eventName) {
+            sharedEventEmitter.off(entry.config.eventName, entry.listener);
+        }
         this.tasks.delete(id);
         this.saveTasksToFile();
         return true;

--- a/src/session/SessionManager.js
+++ b/src/session/SessionManager.js
@@ -132,6 +132,7 @@ class SessionManager {
   }
 
   async _handleIdleTimeout() {
+    await sharedEventEmitter.emit('idleTimeout');
     await this._performCleanup({ reason: 'idle-timeout' });
     await logger.debug('session', 'Idle timeout triggered; history trimmed');
   }
@@ -185,6 +186,8 @@ class SessionManager {
       kept,
       timestamp: new Date().toISOString()
     });
+
+    await sharedEventEmitter.emit('sleep', { reason });
 
     this.updateSystemStatus('ready', 'Session cleanup complete');
 
@@ -266,7 +269,9 @@ class SessionManager {
       
       // Update system status to ready
       this.updateSystemStatus('ready', 'Processing complete');
-      
+
+      await sharedEventEmitter.emit('conversationEnd');
+
       return { ok: true };
     } catch (error) {
       if (signal.aborted) {

--- a/src/tools/sleep.js
+++ b/src/tools/sleep.js
@@ -1,0 +1,84 @@
+const logger = require('../utils/logger');
+const scheduler = require('../core/scheduler');
+
+class SleepTool {
+    constructor() {
+        this.name = 'sleep';
+        this.description = 'Tool for performing session cleanup operations';
+    }
+
+    getCapabilities() {
+        return {
+            name: this.name,
+            description: this.description,
+            actions: [
+                {
+                    name: 'sleep',
+                    description: 'Trigger session cleanup and memory consolidation',
+                    parameters: [
+                        { name: 'clearHistory', description: 'Clear entire conversation history', type: 'boolean', required: false },
+                        { name: 'consolidateMemory', description: 'Consolidate short term to long term memory', type: 'boolean', required: false },
+                        { name: 'reason', description: 'Reason for sleeping', type: 'string', required: false }
+                    ]
+                }
+            ]
+        };
+    }
+
+    async sleep(params) {
+        if (!scheduler.sessionManager) {
+            logger.error('SleepTool', 'Session manager unavailable');
+            return { status: 'error', error: 'session-manager-unavailable' };
+        }
+
+        const options = {
+            clearHistory: false,
+            consolidateMemory: true,
+            reason: 'tool-sleep'
+        };
+
+        const ch = params.find(p => p.name === 'clearHistory');
+        if (ch) options.clearHistory = ch.value === true || ch.value === 'true';
+
+        const cm = params.find(p => p.name === 'consolidateMemory');
+        if (cm) options.consolidateMemory = !(cm.value === false || cm.value === 'false');
+
+        const reason = params.find(p => p.name === 'reason');
+        if (reason && reason.value) options.reason = String(reason.value);
+
+        try {
+            const result = await scheduler.sessionManager.sleep(options);
+            if (result && result.error) {
+                return { status: 'error', error: result.message || result.error };
+            }
+            return { status: 'success', message: result.message || 'Sleep successful' };
+        } catch (err) {
+            logger.error('SleepTool', 'Sleep failed', { error: err.message });
+            return { status: 'error', error: err.message };
+        }
+    }
+
+    async execute(action, parameters) {
+        let parsed = parameters;
+        if (typeof parameters === 'string') {
+            try {
+                parsed = JSON.parse(parameters);
+            } catch (e) {
+                return { status: 'error', error: 'Invalid parameters JSON' };
+            }
+        }
+
+        if (!Array.isArray(parsed)) {
+            parsed = Object.entries(parsed || {}).map(([name, value]) => ({ name, value }));
+        }
+
+        switch (action) {
+            case 'sleep':
+                return await this.sleep(parsed);
+            default:
+                return { status: 'error', error: `Unknown action: ${action}` };
+        }
+    }
+}
+
+module.exports = new SleepTool();


### PR DESCRIPTION
## Summary
- add new `sleep` tool for triggering session cleanup
- extend scheduler to support event-based tasks and tool execution
- update scheduler tool to register tool and event tasks
- emit `idleTimeout`, `sleep`, and `conversationEnd` events in session manager

## Testing
- `npm test` *(fails: spawnSync /bin/sh ENOBUFS)*

------
https://chatgpt.com/codex/tasks/task_e_684d8406c8f083289ef7ea92f8bb102f