### PR TITLE
Improve cleanup logging

### DIFF
--- a/src/session/SessionManager.js
+++ b/src/session/SessionManager.js
@@ -141,16 +141,7 @@ class SessionManager {
     // Update system status
     this.updateSystemStatus('processing', 'Cleaning up session...');
 
-    // Cancel any ongoing processing
-    if (this.busy) {
-      await this.cancelProcessing();
-    }
-
-    // Consolidate memory if requested
-    if (consolidateMemory && core.memory && typeof core.memory.consolidateShortTermToLongTerm === 'function') {
-      await core.memory.consolidateShortTermToLongTerm();
-    }
-
+    // Clear or trim history first so cleanup logs remain visible
     let kept = this.retainExchanges;
 
     if (clearHistory) {
@@ -167,6 +158,16 @@ class SessionManager {
         }
       }
       this.history = exchanges;
+    }
+
+    // Cancel any ongoing processing
+    if (this.busy) {
+      await this.cancelProcessing();
+    }
+
+    // Consolidate memory if requested
+    if (consolidateMemory && core.memory && typeof core.memory.consolidateShortTermToLongTerm === 'function') {
+      await core.memory.consolidateShortTermToLongTerm();
     }
 
     if (this.chatLogWriter) {


### PR DESCRIPTION
## Summary
- keep sleep cleanup logs by clearing history first

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e0a73e0d48328aaf83138518bf919