### PR TITLE
Add event hooks and listing for scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ console.log(`Deleted ${deleted} old cache files, ${errors} errors`);
 - Logs stored under `data/logs`
 - Run tests with `npm test`
 - Cache debug logs are available in the main application logs with the `promptCache` prefix
-- Scheduler tool supports periodic and event-based tasks, including automatic tool execution. Tasks persist in `data/scheduler/tasks.json`.
+- Scheduler tool supports periodic and event-based tasks, including automatic tool execution. Tasks persist in `data/scheduler/tasks.json`. Use `agent scheduler listEvents` to view available trigger events.
 
 ## Memory System
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,8 @@
 
 This release introduces an upgraded scheduler system and a new **sleep** tool.
 Scheduled tasks can now be triggered either at fixed intervals or in response to
-session events such as `startup`, `idleTimeout`, and `conversationEnd`.
+session events such as `startup`, `idleTimeout`, `conversationEnd`,
+`messageProcessed`, `sessionCleanup`, and memory maintenance events.
 
 The sleep tool performs session cleanup and can be invoked manually or by the
 scheduler. Cleanup consolidates memory, trims history and emits a `sleep` event
@@ -20,6 +21,11 @@ agent scheduler addTask '{"message": "ping", "frequencySec": 3600}'
 Trigger a tool when the session becomes idle:
 ```bash
 agent scheduler addEventToolTask '{"eventName": "idleTimeout", "toolName": "sleep", "action": "sleep", "parameters": []}'
+```
+
+List available trigger events:
+```bash
+agent scheduler listEvents
 ```
 
 ### Testing

--- a/src/core/scheduler/index.js
+++ b/src/core/scheduler/index.js
@@ -9,11 +9,23 @@ const toolManager = require('../../mcp');
 const schedulerDir = path.join(DATA_DIR_PATH, 'scheduler');
 const tasksFile = path.join(schedulerDir, 'tasks.json');
 
+const DEFAULT_EVENTS = [
+    'startup',
+    'idleTimeout',
+    'conversationEnd',
+    'sleep',
+    'messageProcessed',
+    'sessionCleanup',
+    'memoryMaintenanceStart',
+    'memoryMaintenanceEnd'
+];
+
 class Scheduler {
     constructor() {
         // id => { config, timer?, listener? }
         this.tasks = new Map();
         this.sessionManager = null;
+        this.supportedEvents = new Set(DEFAULT_EVENTS);
     }
 
     async initialize(sessionManager) {
@@ -169,6 +181,10 @@ class Scheduler {
 
     listTasks() {
         return Array.from(this.tasks.values()).map(t => t.config);
+    }
+
+    getSupportedEvents() {
+        return Array.from(this.supportedEvents);
     }
 }
 

--- a/src/session/SessionManager.js
+++ b/src/session/SessionManager.js
@@ -189,6 +189,7 @@ class SessionManager {
     });
 
     await sharedEventEmitter.emit('sleep', { reason });
+    await sharedEventEmitter.emit('sessionCleanup', { reason });
 
     this.updateSystemStatus('ready', 'Session cleanup complete');
 
@@ -272,6 +273,7 @@ class SessionManager {
       this.updateSystemStatus('ready', 'Processing complete');
 
       await sharedEventEmitter.emit('conversationEnd');
+      await sharedEventEmitter.emit('messageProcessed');
 
       return { ok: true };
     } catch (error) {

--- a/src/tools/memoryMaintenance.js
+++ b/src/tools/memoryMaintenance.js
@@ -1,6 +1,7 @@
 const logger = require('../utils/logger');
 const memory = require('../core/memory');
 const scheduler = require('../core/scheduler');
+const sharedEventEmitter = require('../utils/eventEmitter');
 
 /**
  * MemoryMaintenanceTool - Heavyweight tool for deep memory maintenance tasks.
@@ -30,7 +31,9 @@ class MemoryMaintenanceTool {
      */
     async consolidate() {
         try {
+            await sharedEventEmitter.emit('memoryMaintenanceStart');
             const result = await memory.consolidateLongTerm();
+            await sharedEventEmitter.emit('memoryMaintenanceEnd');
             return { status: 'success', ...result };
         } catch (error) {
             logger.error('MemoryMaintenanceTool', 'Consolidation failed', { error: error.message });
@@ -46,11 +49,13 @@ class MemoryMaintenanceTool {
             return { status: 'error', error: 'session-manager-unavailable' };
         }
         try {
+            await sharedEventEmitter.emit('memoryMaintenanceStart');
             const result = await scheduler.sessionManager.sleep({
                 clearHistory: opts.clearHistory ?? false,
                 consolidateMemory: opts.consolidateMemory ?? true,
                 reason: opts.reason || 'maintenance-cleanup'
             });
+            await sharedEventEmitter.emit('memoryMaintenanceEnd');
             return result.error ? { status: 'error', error: result.error } : { status: 'success', ...result };
         } catch (error) {
             logger.error('MemoryMaintenanceTool', 'Cleanup failed', { error: error.message });

--- a/src/tools/scheduler.js
+++ b/src/tools/scheduler.js
@@ -34,7 +34,7 @@ class SchedulerTool {
                     name: 'addEventTask',
                     description: 'Trigger a message when an event occurs',
                     parameters: [
-                        { name: 'eventName', description: 'Event to listen for', type: 'string', required: true },
+                        { name: 'eventName', description: 'Event to listen for (see listEvents)', type: 'string', required: true },
                         { name: 'message', description: 'Message to process', type: 'string', required: true }
                     ]
                 },
@@ -42,7 +42,7 @@ class SchedulerTool {
                     name: 'addEventToolTask',
                     description: 'Trigger a tool when an event occurs',
                     parameters: [
-                        { name: 'eventName', description: 'Event to listen for', type: 'string', required: true },
+                        { name: 'eventName', description: 'Event to listen for (see listEvents)', type: 'string', required: true },
                         { name: 'toolName', description: 'Tool to execute', type: 'string', required: true },
                         { name: 'action', description: 'Tool action', type: 'string', required: true },
                         { name: 'parameters', description: 'Action parameters (JSON)', type: 'string', required: false }
@@ -61,6 +61,11 @@ class SchedulerTool {
                 {
                     name: 'viewTasks',
                     description: 'Alias for listTasks',
+                    parameters: []
+                },
+                {
+                    name: 'listEvents',
+                    description: 'List available scheduler trigger events',
                     parameters: []
                 }
             ]
@@ -143,6 +148,11 @@ class SchedulerTool {
         return this.listTasks();
     }
 
+    async listEvents() {
+        const events = scheduler.getSupportedEvents();
+        return { status: 'success', events };
+    }
+
     async execute(action, parameters) {
         try {
             let parsed = parameters;
@@ -164,6 +174,8 @@ class SchedulerTool {
                     return await this.listTasks();
                 case 'viewTasks':
                     return await this.viewTasks();
+                case 'listEvents':
+                    return await this.listEvents();
                 default:
                     return { status: 'error', error: `Unknown action: ${action}` };
             }


### PR DESCRIPTION
## Summary
- expose supported events in scheduler and new `listEvents` action
- fire events for message processing, session cleanup and memory maintenance
- document scheduler events and add usage docs

## Testing
- `npm test -- -runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6852a68b67688328895cb5e82d93f8b4