### PR TITLE
Enhance planUpdater with direct result context

### DIFF
--- a/src/core/coordinator/index.js
+++ b/src/core/coordinator/index.js
@@ -110,7 +110,7 @@ async function executePlan(plan, isReplan = false, existingResults = [], startSt
             }
 
             try {
-                const result = await tool.execute(step.action, step.parameters, plan);
+                const result = await tool.execute(step.action, step.parameters, plan, results);
                 logger.debug('Tool execution result:', result);
                 memory.storeShortTerm('toolExecutionResult for' + step.action, JSON.stringify(result), 'ego');
                 await sharedEventEmitter.emit('subsystemMessage', {

--- a/tests/planUpdater.test.js
+++ b/tests/planUpdater.test.js
@@ -31,7 +31,10 @@ describe('planUpdater tool', () => {
     mockChat.mockResolvedValue({ content: JSON.stringify(responseObj) });
     memory.retrieveShortTerm.mockResolvedValue('[]');
 
-    const res = await planUpdater.execute('evalForUpdate', [{ name: 'currentStepNumber', value: 0 }], plan);
+    const results = [
+      { tool: 'dummy', action: 'a', result: { status: 'success', data: {} } }
+    ];
+    const res = await planUpdater.execute('evalForUpdate', [{ name: 'currentStepNumber', value: 0 }], plan, results);
     expect(res.status).toBe('replan');
     expect(res.updatedPlan.steps).toEqual(plan);
     expect(res.nextStepIndex).toBe(1);
@@ -52,7 +55,11 @@ describe('planUpdater tool', () => {
     mockChat.mockResolvedValue({ content: JSON.stringify(responseObj) });
     memory.retrieveShortTerm.mockResolvedValue('[]');
 
-    const res = await planUpdater.execute('evalForUpdate', [{ name: 'currentStepNumber', value: 1 }], plan);
+    const results = [
+      { tool: 'dummy', action: 'a', result: { status: 'success', data: {} } },
+      { tool: 'dummy', action: 'b', result: { status: 'success', data: {} } }
+    ];
+    const res = await planUpdater.execute('evalForUpdate', [{ name: 'currentStepNumber', value: 1 }], plan, results);
     expect(res.status).toBe('success');
     expect(res.nextStepIndex).toBe(2);
   });


### PR DESCRIPTION
## Summary
- remove short-term memory fallback when collecting outputs
- adjust tests for new planUpdater logic

## Testing
- `npx jest tests/planUpdater.test.js --runInBand --ci --silent`
- `npx jest --runInBand --ci` *(fails: settings test)*

------
https://chatgpt.com/codex/tasks/task_e_68552a1f4b608328a3643dea81cc25d9