### PR TITLE
Fix replan execution and simplify context

### DIFF
--- a/tests/coordinatorPlanUpdate.test.js
+++ b/tests/coordinatorPlanUpdate.test.js
@@ -1,0 +1,39 @@
+const { executePlan } = require('../src/core/coordinator');
+const toolManager = require('../src/mcp');
+
+jest.mock('../src/mcp', () => ({
+  getAllTools: jest.fn(),
+}));
+
+const planUpdaterTool = { name: 'planUpdater', execute: jest.fn() };
+const dummyTool = { name: 'dummy', execute: jest.fn() };
+
+describe('executePlan replan handling', () => {
+  beforeEach(() => {
+    planUpdaterTool.execute.mockReset();
+    dummyTool.execute.mockReset();
+    toolManager.getAllTools.mockResolvedValue([planUpdaterTool, dummyTool]);
+  });
+
+  test('updated plan is executed when planUpdater requests replan', async () => {
+    const initialPlan = [
+      { tool: 'planUpdater', action: 'evalForUpdate', parameters: [{ name: 'currentStepNumber', value: 0 }], description: 'check' },
+      { tool: 'dummy', action: 'original', parameters: [], description: 'orig step' }
+    ];
+
+    planUpdaterTool.execute.mockResolvedValue({
+      status: 'replan',
+      message: 'update',
+      updatedPlan: { steps: [ { tool: 'dummy', action: 'updated', parameters: [], description: 'new step' } ] },
+      nextStepIndex: 0
+    });
+
+    dummyTool.execute.mockResolvedValue({ status: 'success' });
+
+    const result = await executePlan(initialPlan);
+
+    expect(dummyTool.execute).toHaveBeenCalledTimes(1);
+    expect(dummyTool.execute.mock.calls[0][0]).toBe('updated');
+    expect(result.status).toBe('success');
+  });
+});

--- a/tests/planUpdater.test.js
+++ b/tests/planUpdater.test.js
@@ -1,9 +1,4 @@
 const planUpdater = require('../src/tools/planUpdater');
-const memory = require('../src/core/memory');
-
-jest.mock('../src/core/memory', () => ({
-  retrieveShortTerm: jest.fn()
-}));
 
 const mockChat = jest.fn();
 jest.mock('../src/utils/openaiClient.js', () => ({
@@ -13,7 +8,6 @@ jest.mock('../src/utils/openaiClient.js', () => ({
 describe('planUpdater tool', () => {
   beforeEach(() => {
     mockChat.mockReset();
-    memory.retrieveShortTerm.mockReset();
   });
 
   test('returns replan when update needed', async () => {
@@ -29,9 +23,11 @@ describe('planUpdater tool', () => {
       next_step_index: 1
     };
     mockChat.mockResolvedValue({ content: JSON.stringify(responseObj) });
-    memory.retrieveShortTerm.mockResolvedValue('[]');
 
-    const res = await planUpdater.execute('evalForUpdate', [{ name: 'currentStepNumber', value: 0 }], plan);
+    const results = [
+      { tool: 'dummy', action: 'a', result: { status: 'success', data: {} } }
+    ];
+    const res = await planUpdater.execute('evalForUpdate', [{ name: 'currentStepNumber', value: 0 }], plan, results);
     expect(res.status).toBe('replan');
     expect(res.updatedPlan.steps).toEqual(plan);
     expect(res.nextStepIndex).toBe(1);
@@ -50,9 +46,12 @@ describe('planUpdater tool', () => {
       next_step_index: 2
     };
     mockChat.mockResolvedValue({ content: JSON.stringify(responseObj) });
-    memory.retrieveShortTerm.mockResolvedValue('[]');
 
-    const res = await planUpdater.execute('evalForUpdate', [{ name: 'currentStepNumber', value: 1 }], plan);
+    const results = [
+      { tool: 'dummy', action: 'a', result: { status: 'success', data: {} } },
+      { tool: 'dummy', action: 'b', result: { status: 'success', data: {} } }
+    ];
+    const res = await planUpdater.execute('evalForUpdate', [{ name: 'currentStepNumber', value: 1 }], plan, results);
     expect(res.status).toBe('success');
     expect(res.nextStepIndex).toBe(2);
   });


### PR DESCRIPTION
## Summary
- stop using memory in planUpdater and rely solely on passed results
- execute updated plan when planUpdater returns a replan result
- export `executePlan` for testability
- add test covering replan execution logic

## Testing
- `npx jest tests/planUpdater.test.js --runInBand --ci --silent`
- `npx jest tests/coordinatorPlanUpdate.test.js --runInBand --ci --silent`
- `npx jest --runInBand --ci` *(fails: settings and reflection tests)*

------
https://chatgpt.com/codex/tasks/task_e_68552a1f4b608328a3643dea81cc25d9