### PR TITLE
Fix plan replan and allow clearing settings

### DIFF
--- a/src/core/coordinator/index.js
+++ b/src/core/coordinator/index.js
@@ -142,13 +142,7 @@ async function executePlan(plan, isReplan = false, existingResults = [], startSt
 
                 if (result.status === 'replan') {
                     logger.debug('Tool execution replan:', result);
-                    // return {
-                    //     status: 'replan',
-                    //     message: result.message,
-                    //     updatedPlan: result.updatedPlan,
-                    //     nextStepIndex: result.nextStep
-                    // };
-                    await executePlan(result.updatedPlan, true, results, result.nextStepIndex);
+                    return await executePlan(result.updatedPlan, true, results, result.nextStepIndex);
                 }
 
                 // Handle the mock tool response format from tests

--- a/src/routes/settingsPage.js
+++ b/src/routes/settingsPage.js
@@ -243,9 +243,11 @@ var buttons=document.querySelectorAll('.settings-tabs button');buttons.forEach(b
       if (val === undefined) {
         return;
       }
-      if (val !== '') {
-        newSettings[field] = transform ? transform(val) : val;
+      if (val === '') {
+        newSettings[field] = '';
+        return;
       }
+      newSettings[field] = transform ? transform(val) : val;
     };
 
     assign('llmModel');


### PR DESCRIPTION
## Summary
- return early when planUpdater requests a replan
- allow clearing individual settings by submitting empty values

## Testing
- `npx --yes jest tests/planUpdater.test.js --runInBand --silent`
- `npx --yes jest tests/settings.test.js --runInBand --silent`
- `npx --yes jest tests/browser.test.js --runInBand --silent`
- `npx --yes jest tests/assemblyToken.test.js --runInBand --silent`
- `npx --yes jest tests/query.test.js --runInBand --silent`
- `npx --yes jest tests/promptCache.test.js --runInBand --silent`
- `npx --yes jest tests/utteranceCheck.test.js --runInBand --silent`
- `npx --yes jest tests/reflection.test.js --runInBand --verbose` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_685539201ac083289fb4a01b2a9d4014