### PR TITLE
Add short-term summary refinement

### DIFF
--- a/config/defaultSettings.json
+++ b/config/defaultSettings.json
@@ -5,6 +5,7 @@
   "queryModel": "gpt-4.1-nano",
   "bubbleModel": "gpt-4.1-nano",
   "reflectionModel": "gpt-4.1-nano",
+  "memoryModel": "gpt-4.1-nano",
   "utteranceCheckModel": "gpt-4.1-nano",
   "maxTokens": 5000,
   "tokenLimit": 10000,

--- a/src/core/memory/index.js
+++ b/src/core/memory/index.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require('path');
 const { DATA_DIR_PATH } = require('../../utils/dataDir');
 const { getOpenAIClient } = require("../../utils/openaiClient.js");
+const { loadSettings } = require('../../utils/settings');
 const logger = require("../../utils/logger.js");
 const prompts = require("./prompts");
 const sharedEventEmitter = require("../../utils/eventEmitter");
@@ -518,7 +519,10 @@ ${memory.content}
           { role: 'system', content: prompts.SHORT_TERM_SUMMARY_SYSTEM },
           { role: 'user', content: prompts.SHORT_TERM_SUMMARY_USER.replace('{{transcript}}', shortContent) }
         ];
-        const response = await this.openaiClient.chat(messages);
+        const settings = loadSettings();
+        const response = await this.openaiClient.chat(messages, {
+          model: settings.memoryModel || settings.llmModel
+        });
         summary = response.content;
       } catch (summErr) {
         logger.error('Memory', 'Error summarizing short term memory', { error: summErr.message });

--- a/src/core/memory/prompts.js
+++ b/src/core/memory/prompts.js
@@ -130,10 +130,21 @@ const CONSOLIDATE_SCHEMA = {
   }
 };
 
+// Prompts for summarizing short-term memory before long-term storage
+// The transcript may contain debug logs, tool traces or other noisy system output.
+// The assistant should distill the true conversation and important facts while ignoring
+// low level debug chatter.
+const SHORT_TERM_SUMMARY_SYSTEM_DEFAULT = `You are a memory summarization assistant. Condense a conversation transcript into a concise summary capturing the key user requests, assistant responses, decisions and outcomes. Ignore debug logs or repetitive tool traces.`;
+const SHORT_TERM_SUMMARY_USER_DEFAULT = `Summarize the following conversation transcript. Omit filler text, debug statements and irrelevant tool output. Capture any key facts, decisions or results in bullet form. Use as many bullets as needed to cover all important information.\n\n{{transcript}}`;
+const SHORT_TERM_SUMMARY_SYSTEM = loadPrompt(MODULE, 'SHORT_TERM_SUMMARY_SYSTEM', SHORT_TERM_SUMMARY_SYSTEM_DEFAULT);
+const SHORT_TERM_SUMMARY_USER = loadPrompt(MODULE, 'SHORT_TERM_SUMMARY_USER', SHORT_TERM_SUMMARY_USER_DEFAULT);
+
 module.exports = {
   RETRIEVE_MEMORY_SYSTEM,
   RETRIEVE_MEMORY_USER,
   CONSOLIDATE_MEMORY_SYSTEM,
   CONSOLIDATE_MEMORY_USER,
-  CONSOLIDATE_SCHEMA
+  CONSOLIDATE_SCHEMA,
+  SHORT_TERM_SUMMARY_SYSTEM,
+  SHORT_TERM_SUMMARY_USER
 };

--- a/src/routes/settingsPage.js
+++ b/src/routes/settingsPage.js
@@ -80,6 +80,10 @@ function registerSettingsRoutes(app, { ego, toolManager }) {
           <span class="setting-input"><input type="text" name="reflectionModel" value="${raw.reflectionModel ?? ''}" placeholder="${defaults.reflectionModel || baseModel}" /></span>
         </label>
         <label>
+          <span class="setting-name">Memory Model:</span>
+          <span class="setting-input"><input type="text" name="memoryModel" value="${raw.memoryModel ?? ''}" placeholder="${defaults.memoryModel || baseModel}" /></span>
+        </label>
+        <label>
           <span class="setting-name">Utterance Check Model:</span>
           <span class="setting-input"><input type="text" name="utteranceCheckModel" value="${raw.utteranceCheckModel ?? ''}" placeholder="${defaults.utteranceCheckModel}" /></span>
         </label>
@@ -199,6 +203,7 @@ var buttons=document.querySelectorAll('.settings-tabs button');buttons.forEach(b
         <label>Query Model:<input type="text" name="queryModel" value="${raw.queryModel ?? ''}" placeholder="${defaults.queryModel || baseModel}" /></label><br/>
         <label>Bubble Model:<input type="text" name="bubbleModel" value="${raw.bubbleModel ?? ''}" placeholder="${defaults.bubbleModel || baseModel}" /></label><br/>
         <label>Reflection Model:<input type="text" name="reflectionModel" value="${raw.reflectionModel ?? ''}" placeholder="${defaults.reflectionModel || baseModel}" /></label><br/>
+        <label>Memory Model:<input type="text" name="memoryModel" value="${raw.memoryModel ?? ''}" placeholder="${defaults.memoryModel || baseModel}" /></label><br/>
         <label>Utterance Check Model:<input type="text" name="utteranceCheckModel" value="${raw.utteranceCheckModel ?? ''}" placeholder="${defaults.utteranceCheckModel}" /></label><br/>
         <label>LLM Max Tokens:<input type="number" name="maxTokens" value="${raw.maxTokens ?? ''}" placeholder="${defaults.maxTokens}" /></label><br/>
         <label>Token Limit:<input type="number" name="tokenLimit" value="${raw.tokenLimit ?? ''}" placeholder="${defaults.tokenLimit}" /></label><br/>
@@ -256,6 +261,7 @@ var buttons=document.querySelectorAll('.settings-tabs button');buttons.forEach(b
     assign('queryModel');
     assign('bubbleModel');
     assign('reflectionModel');
+    assign('memoryModel');
     assign('utteranceCheckModel');
     assign('maxTokens', v => parseInt(v, 10));
     assign('tokenLimit', v => parseInt(v, 10));

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -14,6 +14,7 @@ const fallbackDefaults = {
   queryModel: '',
   bubbleModel: '',
   reflectionModel: '',
+  memoryModel: '',
   utteranceCheckModel: 'gpt-4.1-nano',
   // Default maximum tokens for LLM responses
   maxTokens: 1000,

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -40,6 +40,7 @@ describe('/settings page', () => {
         evaluatorModel: 'evalModel',
         queryModel: 'queryModel',
         bubbleModel: 'bubbleModel',
+        memoryModel: 'memoryModel',
         utteranceCheckModel: 'nano-model',
         maxTokens: 1500,
         ttsVoiceId: 'voiceX',
@@ -56,6 +57,7 @@ describe('/settings page', () => {
     expect(saved.evaluatorModel).toBe('evalModel');
     expect(saved.queryModel).toBe('queryModel');
     expect(saved.bubbleModel).toBe('bubbleModel');
+    expect(saved.memoryModel).toBe('memoryModel');
     expect(saved.utteranceCheckModel).toBe('nano-model');
     expect(saved.maxTokens).toBe(1500);
     expect(saved.ttsVoiceId).toBe('voiceX');
@@ -71,16 +73,17 @@ describe('/settings page', () => {
     await request(app)
       .post('/settings')
       .type('form')
-      .send({ llmModel: 'custom-model' });
+      .send({ llmModel: 'custom-model', memoryModel: 'memCustom' });
 
     // Clear the model
     await request(app)
       .post('/settings')
       .type('form')
-      .send({ llmModel: '' });
+      .send({ llmModel: '', memoryModel: '' });
 
     const saved = loadSettings();
     expect(saved.llmModel).toBe(defaultSettings.llmModel);
+    expect(saved.memoryModel).toBe(defaultSettings.memoryModel);
     expect(saved.maxTokens).toBe(defaultSettings.maxTokens);
     expect(saved.usePromptOverrides).toBe(false);
   });


### PR DESCRIPTION
## Summary
- improve short-term memory summarization prompts
- ignore debug logs and allow as many bullet points as needed

## Testing
- `npm test` *(fails: reflection.test.js due to token limit errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855ee7cfd388328a3a1614fcb449f73