### PR TITLE
Add raw data file editor in settings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -222,6 +222,7 @@
                     <button data-tab="general" class="active" onclick="showSettingsTab('general')">General</button>
                     <button data-tab="prompts" onclick="showSettingsTab('prompts')">Prompts</button>
                     <button data-tab="stats" onclick="showSettingsTab('stats')">Stats</button>
+                    <button data-tab="files" onclick="showSettingsTab('files')">Files</button>
                 </div>
             </div>
             <div class="modal-body" id="settings-output">

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -175,6 +175,7 @@ function loadSettingsContent() {
                 <div id="settings-general" class="settings-tab active">${data.general}</div>
                 <div id="settings-prompts" class="settings-tab">${data.prompts}</div>
                 <div id="settings-stats" class="settings-tab">${data.stats}</div>
+                <div id="settings-files" class="settings-tab">${data.files}</div>
             `;
             
             // Add event listener for the settings form
@@ -185,6 +186,7 @@ function loadSettingsContent() {
                     submitSettingsForm(form);
                 });
             }
+            loadDataFile();
         })
         .catch(error => {
             output.innerHTML = `<div class="error-message">Error loading settings: ${error.message}</div>`;
@@ -249,6 +251,38 @@ function showSettingsTab(tabId) {
             button.classList.remove('active');
         }
     });
+}
+
+function loadDataFile() {
+    const select = document.getElementById('datafile-select');
+    const textarea = document.getElementById('datafile-content');
+    if (!select || !textarea) return;
+    fetch('/datafiles?name=' + encodeURIComponent(select.value))
+        .then(res => res.json())
+        .then(data => {
+            textarea.value = data.content || '';
+        })
+        .catch(err => alert('Error loading file: ' + err.message));
+}
+
+function saveDataFile() {
+    const select = document.getElementById('datafile-select');
+    const textarea = document.getElementById('datafile-content');
+    if (!select || !textarea) return;
+    fetch('/datafiles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: select.value, content: textarea.value })
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data.success) {
+            alert('File saved');
+        } else {
+            alert('Failed to save file');
+        }
+    })
+    .catch(err => alert('Error saving file: ' + err.message));
 }
 
 function capitalizeFirstLetter(string) {

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,9 @@ const initialMessage = process.argv[2];
 const ego = new core.Ego();
 
 const { registerSettingsRoutes } = require('./routes/settingsPage');
+const { registerDataFileRoutes } = require('./routes/dataFiles');
 registerSettingsRoutes(app, { ego, toolManager });
+registerDataFileRoutes(app);
 
 
 

--- a/src/routes/dataFiles.js
+++ b/src/routes/dataFiles.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { DATA_DIR_PATH } = require('../utils/dataDir');
+
+const router = express.Router();
+
+// Map of editable files
+const FILES = {
+  'short-term': path.join(DATA_DIR_PATH, 'memory', 'short', 'short_term.txt'),
+  'long-term': path.join(DATA_DIR_PATH, 'memory', 'long', 'long_term.txt')
+};
+
+router.get('/', (req, res) => {
+  const name = req.query.name;
+  const filePath = FILES[name];
+  if (!filePath) {
+    return res.status(400).json({ error: 'Invalid file name' });
+  }
+  try {
+    const content = fs.existsSync(filePath)
+      ? fs.readFileSync(filePath, 'utf8')
+      : '';
+    res.json({ content });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to read file' });
+  }
+});
+
+router.post('/', (req, res) => {
+  const { name, content } = req.body;
+  const filePath = FILES[name];
+  if (!filePath) {
+    return res.status(400).json({ error: 'Invalid file name' });
+  }
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content || '', 'utf8');
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to save file' });
+  }
+});
+
+function registerDataFileRoutes(app) {
+  app.use('/datafiles', router);
+}
+
+module.exports = { registerDataFileRoutes };

--- a/src/routes/settingsPage.js
+++ b/src/routes/settingsPage.js
@@ -150,11 +150,27 @@ function registerSettingsRoutes(app, { ego, toolManager }) {
         <pre>${longMem.replace(/</g,'&lt;')}</pre>
       </details>
     `;
-    
+
+    const filesContent = `
+      <div id="file-editor">
+        <label>Select File:
+          <select id="datafile-select" onchange="loadDataFile()">
+            <option value="short-term">short_term.txt</option>
+            <option value="long-term">long_term.txt</option>
+          </select>
+        </label>
+        <textarea id="datafile-content" rows="10" style="width:100%;"></textarea>
+        <div class="settings-actions">
+          <button type="button" onclick="saveDataFile()">Save</button>
+        </div>
+      </div>
+    `;
+
     res.json({
       general: generalContent,
       prompts: promptsContent,
-      stats: statsContent
+      stats: statsContent,
+      files: filesContent
     });
   });
 
@@ -183,6 +199,8 @@ function registerSettingsRoutes(app, { ego, toolManager }) {
 function showTab(id){document.querySelectorAll('.settings-tab').forEach(t=>t.classList.remove('active'));document.getElementById(id).classList.add('active');
 var buttons=document.querySelectorAll('.settings-tabs button');buttons.forEach(b=>{if(b.dataset.tab===id){b.classList.add('active');}else{b.classList.remove('active');}});
 }
+function loadDataFile(){const s=document.getElementById('datafile-select');const t=document.getElementById('datafile-content');if(!s||!t)return;fetch('/datafiles?name='+encodeURIComponent(s.value)).then(r=>r.json()).then(d=>{t.value=d.content||'';});}
+function saveDataFile(){const s=document.getElementById('datafile-select');const t=document.getElementById('datafile-content');if(!s||!t)return;fetch('/datafiles',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:s.value,content:t.value})}).then(r=>r.json()).then(d=>{alert(d.success?'File saved':'Failed to save file');});}
 </script>
 </head><body>
 <div class="modal-content" style="margin:40px auto;">
@@ -192,6 +210,7 @@ var buttons=document.querySelectorAll('.settings-tabs button');buttons.forEach(b
       <button data-tab="general" class="active" onclick="showTab('general')">General</button>
       <button data-tab="prompts" onclick="showTab('prompts')">Prompts</button>
       <button data-tab="stats" onclick="showTab('stats')">Stats</button>
+      <button data-tab="files" onclick="showTab('files')">Files</button>
     </div>
   </div>
   <div class="modal-body">
@@ -234,6 +253,18 @@ var buttons=document.querySelectorAll('.settings-tabs button');buttons.forEach(b
       <pre>${shortMem.replace(/</g,'&lt;')}</pre>
       <h3>Long Term Memory</h3>
       <pre>${longMem.replace(/</g,'&lt;')}</pre>
+    </div>
+    <div id="files" class="settings-tab">
+      <div id="file-editor">
+        <label>Select File:
+          <select id="datafile-select" onchange="loadDataFile()">
+            <option value="short-term">short_term.txt</option>
+            <option value="long-term">long_term.txt</option>
+          </select>
+        </label><br/>
+        <textarea id="datafile-content" rows="10" style="width:100%;"></textarea><br/>
+        <button type="button" onclick="saveDataFile()">Save</button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- enable editing memory text files from the settings UI
- add API routes to read and write raw memory files
- register the new route
- extend frontend JS and HTML to support file editing

## Testing
- `npx jest --runInBand --silent` *(fails: Token limit exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68572b2484e083288d2b79f4146b7b0c